### PR TITLE
Add synced_at column to members

### DIFF
--- a/db/migrate/20220321131718_add_synced_at_to_members.rb
+++ b/db/migrate/20220321131718_add_synced_at_to_members.rb
@@ -1,0 +1,5 @@
+class AddSyncedAtToMembers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :members, :synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_17_110414) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_21_131718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_17_110414) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "synced_at"
   end
 
   create_table "notifications", force: :cascade do |t|


### PR DESCRIPTION
We already keep track of when a member was created (using `created_at`) and last updated (using `updated_at`). But if a member is synced without updating data, we don't keep track of that timestamp.

This PR adds a `synced_at` column, which allows us to keep track of the last time a member was synced, regardless of whether the sync resulted in an update.