### PR TITLE
Remove foreign key constraint for member_id in talks table

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,5 +1,5 @@
 class Member < ApplicationRecord
-  has_many :talks, dependent: :destroy
+  has_many :talks
   enum gender: [:male, :female]
 
   validates_presence_of :name, :gender, :birthdate

--- a/db/migrate/20220321144326_remove_member_foreign_key_from_talks.rb
+++ b/db/migrate/20220321144326_remove_member_foreign_key_from_talks.rb
@@ -1,0 +1,5 @@
+class RemoveMemberForeignKeyFromTalks < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :talks, :members
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_21_131718) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_21_144326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,13 +100,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_21_131718) do
   end
 
   create_table "talks", force: :cascade do |t|
-    t.bigint "member_id"
     t.date "date"
     t.string "purpose"
     t.string "topic"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "speaker_name"
+    t.bigint "member_id"
     t.index ["member_id"], name: "index_talks_on_member_id"
   end
 
@@ -132,5 +132,4 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_21_131718) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "services", "users"
-  add_foreign_key "talks", "members"
 end


### PR DESCRIPTION
We need to keep talks around even if a member is deleted, and we need to be able to create a talk without an associated member.