### PR TITLE
Rename phone to phone_number

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,8 +32,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :phone])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :phone, :avatar])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :phone_number])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :phone_number, :avatar])
   end
 
   private

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -115,6 +115,6 @@ class MembersController < ApplicationController
   end
 
   def member_params
-    params.require(:member).permit(:name, :gender, :birthdate, :phone, :email)
+    params.require(:member).permit(:name, :gender, :birthdate, :phone_number, :email)
   end
 end

--- a/app/madmin/resources/member_resource.rb
+++ b/app/madmin/resources/member_resource.rb
@@ -6,7 +6,7 @@ class MemberResource < Madmin::Resource
   attribute :name
   attribute :gender
   attribute :birthdate
-  attribute :phone
+  attribute :phone_number
   attribute :email
   attribute :created_at, form: false
   attribute :updated_at, form: false

--- a/app/madmin/resources/user_resource.rb
+++ b/app/madmin/resources/user_resource.rb
@@ -6,7 +6,7 @@ class UserResource < Madmin::Resource
   attribute :email
   attribute :first_name
   attribute :last_name
-  attribute :phone
+  attribute :phone_number
   attribute :confirmed_at
   attribute :admin
   attribute :reset_password_sent_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
 
   scope :admin, -> { where(admin: true) }
 
-  validates :phone, phone: { allow_blank: true }
+  validates :phone_number, phone: { allow_blank: true }
 
   strip_attributes
 

--- a/app/notifications/incomplete_meeting_notification.rb
+++ b/app/notifications/incomplete_meeting_notification.rb
@@ -19,7 +19,7 @@ class IncompleteMeetingNotification < Noticed::Base
     {
       Body: "#{message} #{url}",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/notifications/missing_meetings_notification.rb
+++ b/app/notifications/missing_meetings_notification.rb
@@ -19,7 +19,7 @@ class MissingMeetingsNotification < Noticed::Base
     {
       Body: "#{message} #{url}",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/notifications/new_user_admin_notification.rb
+++ b/app/notifications/new_user_admin_notification.rb
@@ -20,7 +20,7 @@ class NewUserAdminNotification < Noticed::Base
     {
       Body: "#{message} #{user.name} (#{user.email})",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/notifications/unit_access_approval_notification.rb
+++ b/app/notifications/unit_access_approval_notification.rb
@@ -19,7 +19,7 @@ class UnitAccessApprovalNotification < Noticed::Base
     {
       Body: "#{message} #{url}",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/notifications/unit_access_rejection_notification.rb
+++ b/app/notifications/unit_access_rejection_notification.rb
@@ -19,7 +19,7 @@ class UnitAccessRejectionNotification < Noticed::Base
     {
       Body: "#{message} #{url}",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/notifications/unit_access_request_notification.rb
+++ b/app/notifications/unit_access_request_notification.rb
@@ -19,7 +19,7 @@ class UnitAccessRequestNotification < Noticed::Base
     {
       Body: "#{message} #{url}",
       From: Rails.application.credentials.twilio[:phone_number],
-      To: recipient.phone
+      To: recipient.phone_number
     }
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,7 +17,7 @@
 
       <div class="mb-3">
         <%= f.label "Phone (to receive text messages)" %>
-        <%= f.text_field :phone, class: 'form-control', placeholder: 'XXX-XXX-XXXX' %>
+        <%= f.text_field :phone_number, class: 'form-control', placeholder: 'XXX-XXX-XXXX' %>
       </div>
 
       <div class="mb-3">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div class="mb-3">
-        <%= f.text_field :phone, class: 'form-control', placeholder: "Phone (to receive text messages)" %>
+        <%= f.text_field :phone_number, class: 'form-control', placeholder: "Phone (to receive text messages)" %>
       </div>
 
       <div class="mb-3">

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -35,8 +35,8 @@
 
         <div class="row mb-2">
           <div class="col-12 col-md">
-            <%= form.label :phone %>
-            <%= form.text_field :phone, class: "form-control", placeholder: "XXX-XXX-XXXX" %>
+            <%= form.label :phone_number %>
+            <%= form.text_field :phone_number, class: "form-control", placeholder: "XXX-XXX-XXXX" %>
           </div>
 
           <div class="col-12 col-md">

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -21,7 +21,7 @@
             <% else %>
               <h6><%= "Last talk date: Not found" %></h6>
             <% end %>
-            <h6><%= "Phone: #{member.phone}" %></h6>
+            <h6><%= "Phone: #{member.phone_number}" %></h6>
             <h6><%= "Email: #{member.email}" %></h6>
           </div>
         </div>

--- a/db/migrate/20220414125555_change_phone_to_phone_number_in_users.rb
+++ b/db/migrate/20220414125555_change_phone_to_phone_number_in_users.rb
@@ -1,0 +1,5 @@
+class ChangePhoneToPhoneNumberInUsers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :phone, :phone_number
+  end
+end

--- a/db/migrate/20220414125845_change_phone_to_phone_number_in_members.rb
+++ b/db/migrate/20220414125845_change_phone_to_phone_number_in_members.rb
@@ -1,0 +1,5 @@
+class ChangePhoneToPhoneNumberInMembers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :members, :phone, :phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_13_103648) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_125555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -169,7 +169,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_13_103648) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.bigint "unit_id"
-    t.string "phone"
+    t.string "phone_number"
     t.datetime "approved_at"
     t.integer "approved_by"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_14_125555) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_125845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,7 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_125555) do
     t.string "name"
     t.integer "gender"
     t.date "birthdate"
-    t.string "phone"
+    t.string "phone_number"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Twilio and Noticed both expect a phone number attribute to be called `phone_number`. The two phone number attributes within Edify are each called `phone`.

This PR changes those attributes to `phone_number` to make things easier in the future.