### PR TITLE
Pause member invitations

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -121,6 +121,15 @@ class MembersController < ApplicationController
   end
 
   def member_params
-    params.require(:member).permit(:name, :gender, :birthdate, :phone_number, :email)
+    params.require(:member).permit(
+      :birthdate,
+      :email,
+      :gender,
+      :name,
+      :paused_at,
+      :paused_by,
+      :paused_until,
+      :phone_number,
+      )
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -130,6 +130,6 @@ class MembersController < ApplicationController
       :paused_by,
       :paused_until,
       :phone_number,
-      )
+    )
   end
 end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
 
 module MembersHelper
+  def link_to_pause(member, period)
+    number, unit = period.split
+    paused_until = number.to_i.send(unit).from_now.to_date
+
+    link_to period,
+            member_path(member, member: { paused_until: paused_until, paused_at: Date.today, paused_by: current_user.id }),
+            method: :patch,
+            class: "btn btn-outline-primary"
+  end
 end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -6,7 +6,12 @@ module MembersHelper
     paused_until = number.to_i.send(unit).from_now.to_date
 
     link_to period,
-            member_path(member, member: { paused_until: paused_until, paused_at: Date.today, paused_by: current_user.id }),
+            member_path(member,
+                        member: {
+                          paused_until: paused_until,
+                          paused_at: Date.current,
+                          paused_by: current_user.id
+                        }),
             method: :patch,
             class: "btn btn-outline-primary"
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -41,6 +41,10 @@ class Member < ApplicationRecord
     talks.joins(:meeting).maximum("meetings.date")
   end
 
+  def paused?
+    paused_until? && paused_until > Date.today
+  end
+
   private
 
   def match_talks

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -42,7 +42,7 @@ class Member < ApplicationRecord
   end
 
   def paused?
-    paused_until? && paused_until > Date.today
+    paused_until? && paused_until > Date.current
   end
 
   private

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -16,6 +16,9 @@
       <div class="card-body">
         <div class="row">
           <div class="col">
+            <% if member.paused? %>
+              <h6 class="text-danger"><%= "Invitations paused until #{l(member.paused_until, format: :rfc822)}" %></h6>
+            <% end %>
             <% if member.last_talk_date %>
               <h6><%= "Last talk date: #{l(member.last_talk_date, format: :rfc822)}" %></h6>
             <% else %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -16,6 +16,52 @@
 <div class="d-flex justify-content-center">
   <div class="card bg-light mt-2 w-100" style="max-width: 700px;">
     <div class="card-header">
+      <h4>Pause Invitations</h4>
+    </div>
+    <div class="card-body">
+      <div class="row mb-2">
+        <h6>Don't suggest inviting this member to speak for:</h6>
+      </div>
+      <div class="row">
+        <div class="col">
+          <div class="d-grid gap-2 d-md-block mx-3">
+            <%= link_to_pause(@member, "1 month") %>
+            <%= link_to_pause(@member, "3 months") %>
+            <%= link_to_pause(@member, "6 months") %>
+            <%= link_to_pause(@member, "1 year") %>
+          </div>
+        </div>
+        <div class="col-12 col-md-2 text-md-end mt-4 mt-md-0">
+          <div class="d-grid gap-2 d-md-block mx-3">
+            <%= link_to "Clear", member_path(@member, member: { paused_until: nil, paused_at: nil, paused_by: nil }), method: :patch, class: "btn btn-primary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="d-flex justify-content-center">
+  <div class="card bg-light mt-2 w-100" style="max-width: 700px;">
+    <div class="card-header">
+      <h4>Notes</h4>
+    </div>
+
+    <%= turbo_frame_tag :new_note, target: "_top" do %>
+      <%= render partial: "notes/form", locals: { note: @member.notes.build } %>
+    <% end %>
+
+    <div class="card-body">
+      <%= turbo_frame_tag "notes" do %>
+        <%= render partial: "notes/note", collection: @member.notes.most_recent_first %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="d-flex justify-content-center">
+  <div class="card bg-light mt-2 w-100" style="max-width: 700px;">
+    <div class="card-header">
       <h4>Talks</h4>
     </div>
     <div class="card-body">
@@ -39,24 +85,6 @@
         <% end %>
         </tbody>
       </table>
-    </div>
-  </div>
-</div>
-
-<div class="d-flex justify-content-center">
-  <div class="card bg-light mt-2 w-100" style="max-width: 700px;">
-    <div class="card-header">
-      <h4>Notes</h4>
-    </div>
-
-    <%= turbo_frame_tag :new_note, target: "_top" do %>
-      <%= render partial: "notes/form", locals: { note: @member.notes.build } %>
-    <% end %>
-
-    <div class="card-body">
-      <%= turbo_frame_tag "notes" do %>
-        <%= render partial: "notes/note", collection: @member.notes.most_recent_first %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/db/migrate/20220423004155_add_paused_attributes_to_members.rb
+++ b/db/migrate/20220423004155_add_paused_attributes_to_members.rb
@@ -1,0 +1,7 @@
+class AddPausedAttributesToMembers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :members, :paused_until, :date
+    add_column :members, :paused_at, :date
+    add_column :members, :paused_by, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_16_050553) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_23_004155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_16_050553) do
     t.datetime "updated_at", null: false
     t.datetime "synced_at"
     t.bigint "unit_id"
+    t.date "paused_until"
+    t.date "paused_at"
+    t.integer "paused_by"
     t.index ["name", "birthdate"], name: "index_members_on_name_and_birthdate", unique: true
     t.index ["unit_id"], name: "index_members_on_unit_id"
   end


### PR DESCRIPTION
This PR allows us to pause member invitations for various periods of time:

- 1 month
- 3 months
- 6 months
- 1 year

It seems wise to avoid longer pause periods because circumstances may change. 

Resolves #15