### PR TITLE
Badge Indicators for New and Moved Out

### DIFF
--- a/app/controllers/madmin/import_jobs_controller.rb
+++ b/app/controllers/madmin/import_jobs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Madmin
   class ImportJobsController < Madmin::ResourceController
   end

--- a/app/madmin/resources/import_job_resource.rb
+++ b/app/madmin/resources/import_job_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ImportJobResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -54,6 +54,12 @@ class Member < ApplicationRecord
     time_in_unit.present? && time_in_unit < 1.year
   end
 
+  # @return [Boolean]
+  def not_in_most_recent_sync?
+    synced_at.nil? || (synced_at.to_date < unit.last_synced_on)
+  end
+
+  # @return [Boolean]
   def paused?
     paused_until? && paused_until > Date.current
   end

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -4,8 +4,18 @@
       <div class="card-header">
         <div class="row pt-2">
           <div class="col">
-            <h5 class="font-weight-bold"><%= link_to fa_icon("person"), member_path(member), target: "_top", data: { "bs-toggle" => "tooltip" }, title: "Visit member page" %>&nbsp<%= member.name %></h5>
-            <h6><%= member.bio %></h6>
+            <h5 class="font-weight-bold">
+              <%= link_to fa_icon("person"), member_path(member), target: "_top", data: { "bs-toggle" => "tooltip" }, title: "Visit member page" %>
+              &nbsp<%= member.name %>
+            </h5>
+            <h6>
+              <%= member.bio %>
+              <% if member.not_in_most_recent_sync? %>
+                <%= content_tag(:span, "Moved", class: "badge bg-danger mx-1", data: { "bs-toggle" => "tooltip" }, title: "This member did not appear in the most recent import and may have moved out") %>
+              <% elsif member.new_member? && member.last_talk_date.nil? %>
+                <%= content_tag(:span, "New", class: "badge bg-success mx-1", data: { "bs-toggle" => "tooltip" }, title: "This member is new and has not yet spoken in Sacrament meeting") %>
+              <% end %>
+            </h6>
           </div>
           <div class="col-5 col-md-2 text-end">
             <%= link_to_member_edit(member, class: "mt-1 mt-md-2") %>
@@ -13,13 +23,12 @@
           </div>
         </div>
       </div>
+
       <div class="card-body">
         <div class="row">
           <div class="col">
             <% if member.paused? %>
               <h6 class="text-danger"><%= "Invitations paused until #{l(member.paused_until, format: :rfc822)}" %></h6>
-            <% elsif member.new_member? && member.last_talk_date.nil? %>
-              <h6 class="text-success"><%= "New member who has yet to speak" %></h6>
             <% end %>
 
             <% if member.last_talk_date %>

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -95,6 +95,37 @@ describe ::Member, type: :model do
     end
   end
 
+  describe "#not_in_most_recent_sync?" do
+    let(:result) { member.not_in_most_recent_sync? }
+    let(:unit) { member.unit }
+
+    before { unit.update(last_synced_on: "2022-04-15") }
+
+    context "when the member was synced on the same day as the most recent unit sync" do
+      before { member.update(synced_at: "2022-04-15") }
+
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the member was synced later than the most recent unit sync" do
+      before { member.update(synced_at: "2022-04-20") }
+
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the member was synced earlier than the most recent unit sync" do
+      before { member.update(synced_at: "2022-04-10") }
+
+      it { expect(result).to eq(true) }
+    end
+
+    context "when the member was never synced" do
+      before { member.update(synced_at: nil) }
+
+      it { expect(result).to eq(true) }
+    end
+  end
+
   describe "#paused?" do
     let(:result) { member.paused? }
     before { travel_to("2022-04-15") }


### PR DESCRIPTION
- Adds a green "New" badge for members who may be new (created later than the unit's first sync)
- Adds a red "Moved" badge for members who may have moved (synced earlier than the units last sync)
Resolves #21 and #60