### PR TITLE
Change paused_at to paused_on

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -126,7 +126,7 @@ class MembersController < ApplicationController
       :email,
       :gender,
       :name,
-      :paused_at,
+      :paused_on,
       :paused_by,
       :paused_until,
       :phone_number,

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -9,7 +9,7 @@ module MembersHelper
             member_path(member,
                         member: {
                           paused_until: paused_until,
-                          paused_at: Date.current,
+                          paused_on: Date.current,
                           paused_by: current_user.id
                         }),
             method: :patch,

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -33,7 +33,7 @@
         </div>
         <div class="col-12 col-md-2 text-md-end mt-4 mt-md-0">
           <div class="d-grid gap-2 d-md-block mx-3">
-            <%= link_to "Clear", member_path(@member, member: { paused_until: nil, paused_at: nil, paused_by: nil }), method: :patch, class: "btn btn-primary" %>
+            <%= link_to "Clear", member_path(@member, member: { paused_until: nil, paused_on: nil, paused_by: nil }), method: :patch, class: "btn btn-primary" %>
           </div>
         </div>
       </div>

--- a/db/migrate/20220426135121_rename_paused_at_for_members.rb
+++ b/db/migrate/20220426135121_rename_paused_at_for_members.rb
@@ -1,0 +1,5 @@
+class RenamePausedAtForMembers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :members, :paused_at, :paused_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_26_043301) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_26_135121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -114,7 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_26_043301) do
     t.datetime "synced_at"
     t.bigint "unit_id"
     t.date "paused_until"
-    t.date "paused_at"
+    t.date "paused_on"
     t.integer "paused_by"
     t.index ["name", "birthdate"], name: "index_members_on_name_and_birthdate", unique: true
     t.index ["unit_id"], name: "index_members_on_unit_id"

--- a/spec/fixtures/members.yml
+++ b/spec/fixtures/members.yml
@@ -9,7 +9,7 @@ bartell_randal:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 predovic_mohamed:
   id: 3
@@ -21,7 +21,7 @@ predovic_mohamed:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 hill_waylon:
   id: 4
@@ -33,7 +33,7 @@ hill_waylon:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 nikolaus_jetta:
   id: 6
@@ -45,7 +45,7 @@ nikolaus_jetta:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 zboncak_ivy:
   id: 8
@@ -57,7 +57,7 @@ zboncak_ivy:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 waelchi_lindsey:
   id: 9
@@ -69,7 +69,7 @@ waelchi_lindsey:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 wilderman_kati:
   id: 10
@@ -81,7 +81,7 @@ wilderman_kati:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 barrows_kenneth:
   id: 12
@@ -93,7 +93,7 @@ barrows_kenneth:
   synced_at:
   unit_id: 1
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 luettgen_stefan:
   id: 16
@@ -105,7 +105,7 @@ luettgen_stefan:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 legros_joaquin:
   id: 17
@@ -117,7 +117,7 @@ legros_joaquin:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 anderson_torri:
   id: 19
@@ -129,7 +129,7 @@ anderson_torri:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 torp_cherri:
   id: 20
@@ -141,7 +141,7 @@ torp_cherri:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 hills_julie:
   id: 21
@@ -153,7 +153,7 @@ hills_julie:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 oberbrunner_meghann:
   id: 22
@@ -165,7 +165,7 @@ oberbrunner_meghann:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 collier_elinor:
   id: 23
@@ -177,7 +177,7 @@ collier_elinor:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 harris_staci:
   id: 24
@@ -189,7 +189,7 @@ harris_staci:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 miller_wilton:
   id: 25
@@ -201,7 +201,7 @@ miller_wilton:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 friesen_sammy:
   id: 26
@@ -213,7 +213,7 @@ friesen_sammy:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 kilback_darron:
   id: 27
@@ -225,7 +225,7 @@ kilback_darron:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 hagenes_daryl:
   id: 28
@@ -237,7 +237,7 @@ hagenes_daryl:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 aufderhar_matthew:
   id: 29
@@ -249,7 +249,7 @@ aufderhar_matthew:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:
 heller_yong:
   id: 30
@@ -261,5 +261,5 @@ heller_yong:
   synced_at:
   unit_id: 2
   paused_until:
-  paused_at:
+  paused_on:
   paused_by:


### PR DESCRIPTION
The `*_at` suffix indicates a timestamp, but `paused_at` is actually a date field. 

This PR renames the column and changes usage throughout the code to `paused_on`, reflecting its actual usage.