### PR TITLE
Remove references to services model throughout

### DIFF
--- a/app/madmin/resources/user_resource.rb
+++ b/app/madmin/resources/user_resource.rb
@@ -21,7 +21,6 @@ class UserResource < Madmin::Resource
   # Associations
   attribute :notifications
   attribute :scheduled_meetings
-  attribute :services
   attribute :unit
 
   # Uncomment this to customize the display name of records in the admin area.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,6 @@ class User < ApplicationRecord
 
   has_many :scheduled_meetings, class_name: "Meeting", foreign_key: :scheduler_id, dependent: :nullify
   has_many :notifications, as: :recipient, dependent: :destroy
-  has_many :services, dependent: nil
   has_one :access_request, dependent: :destroy
   belongs_to :unit, optional: true
 

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -7,7 +7,6 @@ namespace :madmin do
   resources :talks
   resources :members
   resources :announcements
-  resources :services
   resources :users
   namespace :active_storage do
     resources :blobs


### PR DESCRIPTION
Cleaning up after removing the `services` table.