### PR TITLE
Remove admin attribute in favor of :admin role

### DIFF
--- a/app/madmin/resources/user_resource.rb
+++ b/app/madmin/resources/user_resource.rb
@@ -8,7 +8,6 @@ class UserResource < Madmin::Resource
   attribute :last_name
   attribute :phone_number
   attribute :confirmed_at
-  attribute :admin
   attribute :role
   attribute :reset_password_sent_at
   attribute :remember_created_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,12 +30,17 @@ class User < ApplicationRecord
   after_commit :send_welcome_notifications
 
   scope :alphabetical, -> { order(:first_name) }
-  scope :admin, -> { where(admin: true) }
+  scope :admin, -> { where(role: :admin) }
 
   validates :first_name, presence: true
   validates :phone_number, phone: { allow_blank: true }
 
   strip_attributes
+
+  def admin?
+    role == "admin"
+  end
+  alias admin admin?
 
   def assigned_to_unit?
     unit_id?

--- a/db/migrate/20220515195803_remove_admin_from_users.rb
+++ b/db/migrate/20220515195803_remove_admin_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_15_165122) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_15_195803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -170,7 +170,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_15_165122) do
     t.string "first_name"
     t.string "last_name"
     t.datetime "announcements_last_read_at"
-    t.boolean "admin", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_token"

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -6,7 +6,6 @@ admin:
   first_name: Admin
   last_name: User
   announcements_last_read_at:
-  admin: true
   confirmed_at: 2022-04-14 16:32:30.544225000 Z
   unit_id:
   phone_number:
@@ -22,7 +21,6 @@ sunny_one:
   first_name: Sunny One
   last_name: User
   announcements_last_read_at:
-  admin: false
   confirmed_at: 2022-04-15 16:32:30.827166000 Z
   unit_id: 1
   phone_number:
@@ -38,7 +36,6 @@ sunny_two:
   first_name: Sunny Two
   last_name: User
   announcements_last_read_at:
-  admin: false
   confirmed_at: 2022-04-16 16:32:31.078429000 Z
   unit_id: 1
   phone_number:
@@ -54,7 +51,6 @@ pleasant_one:
   first_name: Pleasant One
   last_name: User
   announcements_last_read_at:
-  admin: false
   confirmed_at: 2022-04-15 16:32:31.330726000 Z
   unit_id: 2
   phone_number:
@@ -70,7 +66,6 @@ pleasant_two:
   first_name: Pleasant Two
   last_name: User
   announcements_last_read_at:
-  admin: false
   confirmed_at: 2022-04-16 16:32:31.582486000 Z
   unit_id: 2
   phone_number:
@@ -86,7 +81,6 @@ unassigned:
   first_name: Unassigned
   last_name: User
   announcements_last_read_at:
-  admin: false
   confirmed_at: 2022-04-17 20:25:37.567363000 Z
   unit_id:
   phone_number:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,4 +28,22 @@ describe ::User, type: :model do
       end
     end
   end
+
+  describe "admin?" do
+    let(:result) { user.admin? }
+
+    context "when the user is an admin" do
+      let(:user) { users(:admin) }
+      it "returns true" do
+        expect(result).to eq(true)
+      end
+    end
+
+    context "when the user is not an admin" do
+      let(:user) { users(:sunny_one) }
+      it "returns false" do
+        expect(result).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Finishes up removing the `admin` attribute to cut all admin logic over to using the `role` attribute.

Related to #71