### PR TITLE
Move approval persistance to access requests table

### DIFF
--- a/db/migrate/20220521014304_add_approval_columns_to_access_requests.rb
+++ b/db/migrate/20220521014304_add_approval_columns_to_access_requests.rb
@@ -1,0 +1,7 @@
+class AddApprovalColumnsToAccessRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :access_requests, :approved_at, :datetime
+    add_column :access_requests, :approved_by, :integer
+    add_column :access_requests, :approved_role, :integer
+  end
+end

--- a/db/migrate/20220521014448_remove_approval_columns_from_users.rb
+++ b/db/migrate/20220521014448_remove_approval_columns_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveApprovalColumnsFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :approved_at, :datetime
+    remove_column :users, :approved_by, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_21_014304) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_21_014448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -180,8 +180,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_21_014304) do
     t.datetime "confirmation_sent_at"
     t.bigint "unit_id"
     t.string "phone_number"
-    t.datetime "approved_at"
-    t.integer "approved_by"
     t.boolean "notification_preference_email"
     t.boolean "notification_preference_sms"
     t.integer "role"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_15_195803) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_21_014304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_15_195803) do
     t.datetime "rejected_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "approved_at"
+    t.integer "approved_by"
+    t.integer "approved_role"
     t.index ["unit_id", "user_id"], name: "index_access_requests_on_unit_id_and_user_id", unique: true
     t.index ["unit_id"], name: "index_access_requests_on_unit_id"
     t.index ["user_id"], name: "index_access_requests_on_user_id"

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -9,8 +9,6 @@ admin:
   confirmed_at: 2022-04-14 16:32:30.544225000 Z
   unit_id:
   phone_number:
-  approved_at:
-  approved_by:
   notification_preference_email: true
   notification_preference_sms: false
   role: 0
@@ -24,8 +22,6 @@ sunny_one:
   confirmed_at: 2022-04-15 16:32:30.827166000 Z
   unit_id: 1
   phone_number:
-  approved_at:
-  approved_by:
   notification_preference_email: true
   notification_preference_sms: false
   role: 1
@@ -39,8 +35,6 @@ sunny_two:
   confirmed_at: 2022-04-16 16:32:31.078429000 Z
   unit_id: 1
   phone_number:
-  approved_at: 2022-04-17 04:32:31.079809000 Z
-  approved_by: 2
   notification_preference_email: true
   notification_preference_sms: false
   role: 1
@@ -54,8 +48,6 @@ pleasant_one:
   confirmed_at: 2022-04-15 16:32:31.330726000 Z
   unit_id: 2
   phone_number:
-  approved_at:
-  approved_by:
   notification_preference_email: true
   notification_preference_sms: false
   role: 1
@@ -69,8 +61,6 @@ pleasant_two:
   confirmed_at: 2022-04-16 16:32:31.582486000 Z
   unit_id: 2
   phone_number:
-  approved_at: 2022-04-17 04:32:31.583129000 Z
-  approved_by: 4
   notification_preference_email: true
   notification_preference_sms: false
   role: 1
@@ -84,8 +74,6 @@ unassigned:
   confirmed_at: 2022-04-17 20:25:37.567363000 Z
   unit_id:
   phone_number:
-  approved_at:
-  approved_by:
   notification_preference_email: true
   notification_preference_sms: false
   role: 1


### PR DESCRIPTION
It seems wrong to persist approval information on the `users` table when we have an `access_requests` table that can store it. Currently, we are storing this information on the `users` table, and we are deleting individual access requests when granted. 

This PR deletes approval-related columns from the `users` table and adds them to the `access_requests` table.