### PR TITLE
Revise authorization policies and hide unnecessary buttons

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -19,7 +19,7 @@ class AccessRequest < ApplicationRecord
   def status
     if rejected_at?
       :rejected
-    elsif user.approved_at?
+    elsif approved_at?
       :approved
     else
       :pending

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,8 @@ class User < ApplicationRecord
   strip_attributes
 
   def access_to_lcr?
-    admin? || bishopric? || clerk?
+    admin? ||
+      (assigned_to_unit? && (bishopric? || clerk?))
   end
 
   def admin?
@@ -49,7 +50,7 @@ class User < ApplicationRecord
   alias admin admin?
 
   def approver?
-    admin? || bishopric?
+    unit_admin?
   end
 
   def assigned_to_unit?
@@ -70,6 +71,11 @@ class User < ApplicationRecord
 
   def pending_unit
     access_request&.unit
+  end
+
+  def unit_admin?
+    admin? ||
+      (assigned_to_unit? && bishopric?)
   end
 
   def unit_name

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,35 +9,35 @@ class ApplicationPolicy
   end
 
   def index?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.access_to_lcr?
   end
 
   def show?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.access_to_lcr?
   end
 
   def create?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   def new?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   def update?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   def edit?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   def destroy?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   def upsert?
-    user.access_to_lcr? && user.assigned_to_unit?
+    user.unit_admin?
   end
 
   class Scope

--- a/app/views/meetings/_meeting.html.erb
+++ b/app/views/meetings/_meeting.html.erb
@@ -17,10 +17,12 @@
               <%= meeting.meeting_type.humanize %>
             </div>
           </div>
-          <div class="col-12 col-md-2 text-md-end">
-            <%= link_to_meeting_edit(meeting, class: "mt-2 mt-md-2") %>
-            <%= link_to_meeting_delete(meeting, class: "mt-2 mt-md-2") %>
-          </div>
+          <% if current_user.unit_admin? %>
+            <div class="col-12 col-md-2 text-md-end">
+              <%= link_to_meeting_edit(meeting, class: "mt-2 mt-md-2") %>
+              <%= link_to_meeting_delete(meeting, class: "mt-2 mt-md-2") %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="card-body">
@@ -30,15 +32,17 @@
               <%= render partial: "talks/talk_mini", collection: meeting.talks, as: :talk %>
             <% end %>
           </div>
-          <div class="col-12">
-            <%= turbo_frame_tag "new_meeting_#{meeting.id}_talk" do %>
-              <%= link_to fa_icon("plus", text: " Add talk"),
-                          new_meeting_talk_path(meeting),
-                          data: { turbo_frame: "new_meeting_#{meeting.id}_talk" },
-                          class: "btn btn-primary btn-sm"
-              %>
-            <% end %>
-          </div>
+          <% if current_user.unit_admin? %>
+            <div class="col-12">
+              <%= turbo_frame_tag "new_meeting_#{meeting.id}_talk" do %>
+                <%= link_to fa_icon("plus", text: " Add talk"),
+                            new_meeting_talk_path(meeting),
+                            data: { turbo_frame: "new_meeting_#{meeting.id}_talk" },
+                            class: "btn btn-primary btn-sm"
+                %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -17,14 +17,15 @@
 </div>
 
 <hr/>
-
-<div class="d-flex justify-content-center">
-  <div class="my-2 w-100" style="max-width: 700px;">
-    <%= turbo_frame_tag :new_meeting do %>
-      <%= link_to fa_icon("plus", text: " Add"), new_meeting_path, data: { turbo_frame: "new_meeting" }, class: "btn btn-primary btn-sm" %>
-    <% end %>
+<% if current_user.unit_admin? %>
+  <div class="d-flex justify-content-center">
+    <div class="my-2 w-100" style="max-width: 700px;">
+      <%= turbo_frame_tag :new_meeting do %>
+        <%= link_to fa_icon("plus", text: " Add"), new_meeting_path, data: { turbo_frame: "new_meeting" }, class: "btn btn-primary btn-sm" %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <article>
   <%= turbo_frame_tag "page_handler" %>

--- a/app/views/talks/_talk_mini.html.erb
+++ b/app/views/talks/_talk_mini.html.erb
@@ -19,10 +19,12 @@
         <h6>"<%= talk.topic %>"</h6>
       <% end %>
     </div>
-    <div class="col-12 col-md-2 text-md-end">
-      <%= link_to_talk_edit(talk) %>
-      <%= link_to_talk_delete(talk) %>
-    </div>
+    <% if current_user.unit_admin? %>
+      <div class="col-12 col-md-2 text-md-end">
+        <%= link_to_talk_edit(talk) %>
+        <%= link_to_talk_delete(talk) %>
+      </div>
+    <% end %>
   </div>
   <hr/>
 <% end %>


### PR DESCRIPTION
This PR reworks authorization policies to cover the expanded list of roles now available. Specifically, by default it limits index and show actions to users with LCR access, and limits all other actions (create/update/delete) to unit administrators. 

It also hides various "Add," "Edit," and "Delete" buttons from users who are not authorized to perform those functions.

Addresses a portion of #71 