### PR TITLE
Add system tests for user lists and onboarding

### DIFF
--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -103,3 +103,16 @@ unassigned:
   notification_preference_email: true
   notification_preference_sms: false
   role:
+new_unit:
+  id: 9
+  email: newunit@example.com
+  encrypted_password: "$2a$12$uBqy3jmS5ioFQ0hwijSLWu3iMlDwVyHSpXuodwYWY.0HOdoaIoWfa"
+  first_name: New
+  last_name: Unit User
+  announcements_last_read_at:
+  confirmed_at: 2022-05-27 04:56:17.484126000 Z
+  unit_id:
+  phone_number:
+  notification_preference_email: true
+  notification_preference_sms: false
+  role:

--- a/spec/system/user_access_approval_spec.rb
+++ b/spec/system/user_access_approval_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Handle access request by a new user", type: :system do
+  let(:reviewing_user) { users(:sunny_bishopric) }
+  let(:requesting_user) { users(:unassigned) }
+  let(:access_request) { requesting_user.access_request }
+
+  context "when access is granted" do
+    scenario "with bishopric role" do
+      login_as reviewing_user, scope: :user
+      navigate_to_review_screen
+
+      find("#role").find(:xpath, "option[contains(text(), 'Bishopric')]").select_option
+      click_button("Approve")
+
+      expect(page).to have_current_path(users_path)
+      requesting_user.reload
+      expect(requesting_user.unit).to eq(reviewing_user.unit)
+      expect(requesting_user.role).to eq("bishopric")
+
+      access_request.reload
+      expect(access_request).to be_approved
+    end
+
+    scenario "with music role" do
+      login_as reviewing_user, scope: :user
+      navigate_to_review_screen
+
+      find("#role").find(:xpath, "option[contains(text(), 'Music')]").select_option
+      click_button("Approve")
+
+      expect(page).to have_current_path(users_path)
+      requesting_user.reload
+      expect(requesting_user.unit).to eq(reviewing_user.unit)
+      expect(requesting_user.role).to eq("music")
+
+      access_request.reload
+      expect(access_request).to be_approved
+    end
+  end
+
+  context "when access is rejected" do
+    before { driven_by :selenium_chrome_headless }
+
+    scenario "Access request is rejected" do
+      login_as reviewing_user, scope: :user
+      navigate_to_review_screen
+
+      accept_alert do
+        click_link("Reject")
+      end
+
+      expect(page).to have_current_path(users_path)
+      requesting_user.reload
+      expect(requesting_user.unit).to be_nil
+      expect(requesting_user.role).to be_nil
+
+      access_request.reload
+      expect(access_request).to be_rejected
+    end
+  end
+
+  def navigate_to_review_screen
+    visit users_path
+    expect(page).to have_text("Access Requests")
+    click_link("Review", href: review_access_request_path(access_request))
+
+    expect(page).to have_text("Review Access Request")
+  end
+end

--- a/spec/system/user_index_spec.rb
+++ b/spec/system/user_index_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Visit the users index", type: :system do
+  let(:unit) { units(:sunny_hills) }
+  let(:admin) { users(:admin) }
+  let(:bishopric_user) { users(:sunny_bishopric) }
+  let(:clerk_user) { users(:sunny_clerk) }
+  let(:music_user) { users(:sunny_music) }
+  let(:program_user) { users(:sunny_program) }
+  let(:unassigned_user) { users(:unassigned) }
+  let(:new_unit_user) { users(:new_unit) }
+
+  context "when the user is a visitor" do
+    it "does not permit access" do
+      visit users_path
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content("You need to sign in or sign up before continuing")
+    end
+  end
+
+  context "when the user is an admin without a unit assigned" do
+    before { login_as admin, scope: :user }
+    it "does not permit access" do
+      visit users_path
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Not authorized")
+    end
+  end
+
+  context "when the user is in a bishopric" do
+    before { login_as bishopric_user, scope: :user }
+    it "lists all users and access requests" do
+      visit users_path
+      verify_users_present
+      verify_access_requests_present
+    end
+  end
+
+  context "when the user is a clerk" do
+    before { login_as clerk_user, scope: :user }
+    it "lists all users but not access requests" do
+      visit users_path
+      verify_users_present
+      verify_access_requests_absent
+    end
+  end
+
+  context "when the user is a music person" do
+    before { login_as music_user, scope: :user }
+    it "lists all users but not access requests" do
+      visit users_path
+      verify_users_present
+      verify_access_requests_absent
+    end
+  end
+
+  context "when the user is a program person" do
+    before { login_as program_user, scope: :user }
+    it "lists all users but not access requests" do
+      visit users_path
+      verify_users_present
+      verify_access_requests_absent
+    end
+  end
+
+  context "when the user is not assigned to the ward" do
+    before { login_as unassigned_user, scope: :user }
+    it "does not permit access" do
+      visit users_path
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Not authorized")
+    end
+  end
+
+  def verify_users_present
+    expect(page).to have_text "Users"
+
+    unit.users.each do |user|
+      expect(page).to have_text(user.name)
+    end
+  end
+
+  def verify_access_requests_present
+    expect(page).to have_text "Access Requests"
+
+    unit.access_requests.each do |access_request|
+      expect(page).to have_text(access_request.user.name)
+    end
+  end
+
+  def verify_access_requests_absent
+    expect(page).not_to have_text "Access Requests"
+
+    unit.access_requests.each do |access_request|
+      expect(page).not_to have_text(access_request.user.name)
+    end
+  end
+end

--- a/spec/system/user_index_spec.rb
+++ b/spec/system/user_index_spec.rb
@@ -22,6 +22,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is an admin without a unit assigned" do
     before { login_as admin, scope: :user }
+
     it "does not permit access" do
       visit users_path
       expect(page).to have_current_path(root_path)
@@ -31,6 +32,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is in a bishopric" do
     before { login_as bishopric_user, scope: :user }
+
     it "lists all users and access requests" do
       visit users_path
       verify_users_present
@@ -40,6 +42,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is a clerk" do
     before { login_as clerk_user, scope: :user }
+
     it "lists all users but not access requests" do
       visit users_path
       verify_users_present
@@ -49,6 +52,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is a music person" do
     before { login_as music_user, scope: :user }
+
     it "lists all users but not access requests" do
       visit users_path
       verify_users_present
@@ -58,6 +62,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is a program person" do
     before { login_as program_user, scope: :user }
+
     it "lists all users but not access requests" do
       visit users_path
       verify_users_present
@@ -67,6 +72,7 @@ describe "Visit the users index", type: :system do
 
   context "when the user is not assigned to the ward" do
     before { login_as unassigned_user, scope: :user }
+
     it "does not permit access" do
       visit users_path
       expect(page).to have_current_path(root_path)

--- a/spec/system/user_onboarding_spec.rb
+++ b/spec/system/user_onboarding_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 describe "Onboard a new user", type: :system do
   let(:new_unit_user) { users(:new_unit) }
   context "when the user has not requested access" do
-
     scenario "the user creates a new ward unit" do
       login_as new_unit_user, scope: :user
       navigate_to_onboard_page
@@ -13,7 +12,7 @@ describe "Onboard a new user", type: :system do
 
       expect(page).to have_text("Set Up A New Ward")
       fill_in :unit_name, with: "Fountain Valley Ward"
-      expect { click_button "Create Ward" }.to change { Unit.count }.by(1)
+      expect { click_button "Create Ward" }.to change(Unit, :count).by(1)
 
       new_unit = Unit.last
       new_unit_user.reload
@@ -36,7 +35,7 @@ describe "Onboard a new user", type: :system do
 
         expect(page).to have_text("Request Access")
         fill_in :access_request_unit_name, with: existing_unit.name
-        expect { click_button "Submit Request" }.not_to change { Unit.count }
+        expect { click_button "Submit Request" }.not_to change(Unit, :count)
 
         new_unit_user.reload
         expect(new_unit_user.unit).to be_nil
@@ -58,7 +57,7 @@ describe "Onboard a new user", type: :system do
 
         expect(page).to have_text("Request Access")
         fill_in :access_request_unit_name, with: existing_unit.name
-        expect { click_button "Submit Request" }.not_to change { Unit.count }
+        expect { click_button "Submit Request" }.not_to change(Unit, :count)
 
         new_unit_user.reload
         expect(new_unit_user.unit).to be_nil

--- a/spec/system/user_onboarding_spec.rb
+++ b/spec/system/user_onboarding_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Onboard a new user", type: :system do
+  let(:new_unit_user) { users(:new_unit) }
+  context "when the user has not requested access" do
+
+    scenario "the user creates a new ward unit" do
+      login_as new_unit_user, scope: :user
+      navigate_to_onboard_page
+      click_link "I need to set up my ward"
+
+      expect(page).to have_text("Set Up A New Ward")
+      fill_in :unit_name, with: "Fountain Valley Ward"
+      expect { click_button "Create Ward" }.to change { Unit.count }.by(1)
+
+      new_unit = Unit.last
+      new_unit_user.reload
+      expect(new_unit_user.unit).to eq(new_unit)
+      expect(new_unit_user.role).to eq("bishopric")
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_text("Fountain Valley Ward")
+    end
+  end
+
+  context "when the user has requested access" do
+    let(:existing_unit) { units(:pleasant_forest) }
+
+    context "when the user is not on the existing ward roster" do
+      scenario "the user requests access to an existing ward unit" do
+        login_as new_unit_user, scope: :user
+        navigate_to_onboard_page
+        click_link "My ward already uses Edify"
+
+        expect(page).to have_text("Request Access")
+        fill_in :access_request_unit_name, with: existing_unit.name
+        expect { click_button "Submit Request" }.not_to change { Unit.count }
+
+        new_unit_user.reload
+        expect(new_unit_user.unit).to be_nil
+        expect(new_unit_user.role).to be_nil
+        expect(new_unit_user.access_request).to be_nil
+
+        expect(page).to have_current_path(new_access_request_path)
+        expect(page).to have_text("We could not find #{new_unit_user.email} in the roster of #{existing_unit.name}")
+      end
+    end
+
+    context "when the user is on the existing ward roster" do
+      before { new_unit_user.update(email: existing_unit.members.last.email) }
+
+      scenario "the user requests access to an existing ward unit" do
+        login_as new_unit_user, scope: :user
+        navigate_to_onboard_page
+        click_link "My ward already uses Edify"
+
+        expect(page).to have_text("Request Access")
+        fill_in :access_request_unit_name, with: existing_unit.name
+        expect { click_button "Submit Request" }.not_to change { Unit.count }
+
+        new_unit_user.reload
+        expect(new_unit_user.unit).to be_nil
+        expect(new_unit_user.role).to be_nil
+        expect(new_unit_user.access_request).to be_present
+        expect(new_unit_user.access_request.unit).to eq(existing_unit)
+        expect(new_unit_user.access_request.status).to eq(:pending)
+
+        expect(page).to have_current_path(root_path)
+        expect(page).to have_text("Your request for access to #{existing_unit.name} is pending")
+      end
+    end
+  end
+
+  def navigate_to_onboard_page
+    visit root_path
+    click_link "Assign my Ward Unit"
+
+    expect(page).to have_text("Assign My Ward Unit")
+    expect(page).to have_link("My ward already uses Edify", href: new_access_request_path)
+    expect(page).to have_link("I need to set up my ward", href: new_unit_path)
+  end
+end

--- a/spec/system/visit_home_page_spec.rb
+++ b/spec/system/visit_home_page_spec.rb
@@ -9,6 +9,7 @@ describe "Visit the home page", type: :system do
   let(:music_user) { users(:sunny_music) }
   let(:program_user) { users(:sunny_program) }
   let(:unassigned_user) { users(:unassigned) }
+  let(:new_unit_user) { users(:new_unit) }
 
   scenario "The user is a visitor" do
     visit root_path
@@ -88,13 +89,25 @@ describe "Visit the home page", type: :system do
     verify_admin_links_absent
   end
 
-  scenario "The user is an unassigned non-admin user" do
+  scenario "The user is an unassigned user with an outstanding access request" do
     login_as unassigned_user, scope: :user
     visit root_path
 
     expect(page).to have_link("Edify", href: root_path)
     expect(page).to have_link(href: notifications_path)
     expect(page).to have_text("Your request for access to #{unassigned_user.access_request.unit_name} is pending")
+
+    verify_admin_links_absent
+  end
+
+  scenario "The user is an unassigned user who has not requested access" do
+    login_as new_unit_user, scope: :user
+    visit root_path
+
+    expect(page).to have_link("Edify", href: root_path)
+    expect(page).to have_link(href: notifications_path)
+    expect(page).to have_text("Looks like you aren't yet assigned to a Ward unit")
+    expect(page).to have_link("Assign my Ward Unit", href: onboard_path)
 
     verify_admin_links_absent
   end


### PR DESCRIPTION
This PR adds a few more system specs:
- Visit users index
- New user onboarding
- Accept and reject access requests

Addresses a portion of #83