### PR TITLE
Fix import jobs show view

### DIFF
--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -2,9 +2,8 @@
 
 class ImportJobsController < ApplicationController
   before_action :authenticate_user!
-  before_action :authorize_import_job, only: %i[show destroy]
-  before_action :authorize_action, except: %i[show destroy]
-  before_action :set_import_job, only: [:show, :destroy]
+  before_action :authorize_user
+  before_action :set_import_job, only: %i[show destroy]
   after_action :verify_authorized
 
   # GET /import_jobs
@@ -46,19 +45,11 @@ class ImportJobsController < ApplicationController
 
   private
 
-  def authorize_import_job
-    authorize @import_job
-  end
-
-  def authorize_action
-    authorize ::ImportJob
-  end
-
   def import_job_params
     params.require(:import_job).permit(:data_string)
   end
 
   def set_import_job
-    @import_job = ::ImportJob.find(params[:id])
+    @import_job = current_unit.import_jobs.find(params[:id])
   end
 end

--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -3,6 +3,7 @@
 module FixtureHelper
   FIXTURE_TABLES = [
     :access_requests,
+    :import_jobs,
     :meetings,
     :members,
     :notes,

--- a/spec/fixtures/files/raw_member_list_sunny_hills.txt
+++ b/spec/fixtures/files/raw_member_list_sunny_hills.txt
@@ -1,0 +1,42 @@
+
+Membership
+Organizations
+Reports
+Ministering
+Finance
+Applications
+Other
+Help
+
+ Search
+My Ward
+Other Units and Leaders
+
+Sunny Hills Stake (1234)
+Sunny Hills 3rd Ward (5678)
+Member List
+
+Print
+
+Individuals
+Households
+
+Show
+
+	Name	Gender	Age	Birth Date	Phone Number	E-mail
+	Barrows, Kenneth	M	13	14 Aug 2008	959-922-0653	victor_schmeler@wiza.co.uk
+	Bartell, Bernice	F	26	19 Jan 1996	553-783-8373	mira@walkerfarrell.us
+	Bartell, Randal	M	25	19 Mar 1997	553-783-8372	nola@walkerfarrell.us
+	Bartell, Winny	F	3	12 Apr 2019
+	Hill, Waylon	M	53	19 Oct 1968	601-915-6744	jorge.yost@oreilly.info
+	Nikolaus, Jetta	F	66	06 Mar 1956	623-880-6552	beckie.stoltenberg@kuhnmcglynn.us
+	Predovic, Mohamed	M	28	22 Feb 1994	254-579-2969	sunny@abernathy.com
+	User, Unassigned	M	55	04 Apr 1967	496-873-2331	unassigned@example.com
+	Waelchi, Lindsey	F	48	25 Nov 1973	521-521-5688	josefa.kessler@leschpaucek.ca
+	Wilderman, Kati	F	17	26 Mar 2005	934-220-0918	gregorio@kuhn.name
+	Zboncak, Ivy	F	40	11 Mar 1982	650-484-9073	darleen@west.us
+Count: 11
+* Unbaptized members of record age 9 and over and those baptized but not confirmed are not included in unit statistics or Quarterly Reports.
+  Send Feedback
+
+Contact Us

--- a/spec/fixtures/import_jobs.yml
+++ b/spec/fixtures/import_jobs.yml
@@ -1,0 +1,24 @@
+---
+import_job_7:
+  id: 7
+  unit_id: 1
+  status: 4
+  status_text:
+  row_count: 10
+  succeeded_count: 9
+  failed_count: 0
+  ignored_count: 1
+  started_at: 2022-03-15 13:57:51.083603000 Z
+  elapsed_seconds: 0
+  error_message:
+  logs: |
+    Saved:   Barrows, Kenneth
+    Saved:   Bartell, Randal
+    Ignored: Bartell, Winny
+    Saved:   Hill, Waylon
+    Saved:   Nikolaus, Jetta
+    Saved:   Predovic, Mohamed
+    Saved:   User, Unassigned
+    Saved:   Waelchi, Lindsey
+    Saved:   Wilderman, Kati
+    Saved:   Zboncak, Ivy

--- a/spec/system/import_job_show_spec.rb
+++ b/spec/system/import_job_show_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Visit an import job show page", type: :system do
+  let(:unit) { units(:sunny_hills) }
+  let(:import_job) { import_jobs(:import_job_7) }
+
+  let(:bishopric_user) { users(:sunny_bishopric) }
+  let(:clerk_user) { users(:sunny_clerk) }
+  let(:music_user) { users(:sunny_music) }
+  let(:program_user) { users(:sunny_program) }
+  let(:unassigned_user) { users(:unassigned) }
+  let(:other_unit_user) { users(:pleasant_one) }
+
+  context "when the user is a visitor" do
+    it "does not permit access" do
+      visit_page
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content("You need to sign in or sign up before continuing")
+    end
+  end
+
+  context "when the user is in a bishopric" do
+    before { login_as bishopric_user, scope: :user }
+
+    it "shows the import job" do
+      visit_page
+      verify_expected_items_present
+    end
+  end
+
+  context "when the user is a clerk" do
+    before { login_as clerk_user, scope: :user }
+
+    it "lists all talks" do
+      visit_page
+      verify_expected_items_present
+    end
+  end
+
+  context "when the user is a music person" do
+    before { login_as music_user, scope: :user }
+
+    it "does not permit access" do
+      visit_page
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Not authorized")
+    end
+  end
+
+  context "when the user is a program person" do
+    before { login_as program_user, scope: :user }
+
+    it "does not permit access" do
+      visit_page
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Not authorized")
+    end
+  end
+
+  context "when the user is not assigned to a ward" do
+    before { login_as unassigned_user, scope: :user }
+
+    it "does not permit access" do
+      visit_page
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Not authorized")
+    end
+  end
+
+  context "when the user is in the bishopric of another ward" do
+    before { login_as other_unit_user, scope: :user}
+
+    it "returns not found" do
+      expect { visit_page }.to raise_error ::ActiveRecord::RecordNotFound
+    end
+  end
+
+  def visit_page
+    visit import_job_path(import_job)
+  end
+
+  def verify_expected_items_present
+    expect(page).to have_text("Import Job 7")
+  end
+end

--- a/spec/system/import_job_show_spec.rb
+++ b/spec/system/import_job_show_spec.rb
@@ -70,7 +70,7 @@ describe "Visit an import job show page", type: :system do
   end
 
   context "when the user is in the bishopric of another ward" do
-    before { login_as other_unit_user, scope: :user}
+    before { login_as other_unit_user, scope: :user }
 
     it "returns not found" do
       expect { visit_page }.to raise_error ::ActiveRecord::RecordNotFound

--- a/spec/system/import_jobs_index_spec.rb
+++ b/spec/system/import_jobs_index_spec.rb
@@ -9,7 +9,6 @@ describe "Visit the import jobs index", type: :system do
   let(:music_user) { users(:sunny_music) }
   let(:program_user) { users(:sunny_program) }
   let(:unassigned_user) { users(:unassigned) }
-  let(:new_unit_user) { users(:new_unit) }
 
   context "when the user is a visitor" do
     it "does not permit access" do
@@ -22,7 +21,7 @@ describe "Visit the import jobs index", type: :system do
   context "when the user is in a bishopric" do
     before { login_as bishopric_user, scope: :user }
 
-    it "lists all talks" do
+    it "lists all import jobs" do
       visit import_jobs_path
       verify_expected_items_present
     end
@@ -31,7 +30,7 @@ describe "Visit the import jobs index", type: :system do
   context "when the user is a clerk" do
     before { login_as clerk_user, scope: :user }
 
-    it "lists all talks" do
+    it "lists all import jobs" do
       visit import_jobs_path
       verify_expected_items_present
     end


### PR DESCRIPTION
The import jobs show view is broken because of faulty authorization logic. This PR fixes that logic and adds a system spec to ensure access to that view.

Resolves #98 