### PR TITLE
Positions for talks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "sprockets-rails"
 gem "stimulus-rails"
 gem "turbo-rails"
 
+gem "acts_as_list"
 gem "american_date"
 gem "aws-sdk-s3", require: false
 gem "cssbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts_as_list (1.0.4)
+      activerecord (>= 4.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     american_date (1.2.0)
@@ -398,6 +400,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_list
   american_date
   aws-sdk-s3
   bootsnap

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Meeting < ApplicationRecord
-  has_many :talks, dependent: nil
+  has_many :talks, -> { order(position: :asc) }, dependent: nil
   belongs_to :unit
   belongs_to :scheduler, class_name: "User", optional: true
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -14,6 +14,7 @@ class Talk < ApplicationRecord
 
   belongs_to :meeting
   belongs_to :member, optional: true
+  acts_as_list scope: :meeting
 
   validates :speaker_name, presence: true
 

--- a/db/migrate/20220619174712_add_position_to_talks.rb
+++ b/db/migrate/20220619174712_add_position_to_talks.rb
@@ -1,0 +1,5 @@
+class AddPositionToTalks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :talks, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_27_210509) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_19_174712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -152,6 +152,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_27_210509) do
     t.string "speaker_name"
     t.bigint "member_id"
     t.bigint "meeting_id"
+    t.integer "position"
     t.index ["meeting_id"], name: "index_talks_on_meeting_id"
     t.index ["member_id"], name: "index_talks_on_member_id"
   end

--- a/lib/tasks/temp/set_positions.rake
+++ b/lib/tasks/temp/set_positions.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :temp do
+  desc "Sets user roles"
+  task set_positions: :environment do
+    Rails.application.eager_load!
+
+    Meeting.find_each do |meeting|
+      puts "Setting positions for talks in meeting for #{I18n.l(meeting.date, format: :rfc822)}"
+      meeting.talks.order(:updated_at).each.with_index(1) do |talk, index|
+        talk.update_column(:position, index)
+      end
+    end
+
+    puts "Finished setting positions"
+  end
+end

--- a/spec/fixtures/talks.yml
+++ b/spec/fixtures/talks.yml
@@ -6,6 +6,7 @@ talk_1:
   speaker_name: Barrows, Kenneth
   member_id: 12
   meeting_id: 2
+  position: 1
 talk_2:
   id: 2
   purpose:
@@ -13,6 +14,7 @@ talk_2:
   speaker_name: Hill, Waylon
   member_id: 4
   meeting_id: 2
+  position: 2
 talk_3:
   id: 3
   purpose: Stake Representative
@@ -20,6 +22,7 @@ talk_3:
   speaker_name: Ghibli, Gordon
   member_id:
   meeting_id: 2
+  position: 3
 talk_4:
   id: 4
   purpose: New Ward Member
@@ -27,6 +30,7 @@ talk_4:
   speaker_name: Nikolaus, Jetta
   member_id: 6
   meeting_id: 3
+  position: 1
 talk_5:
   id: 5
   purpose: Departing Missionary
@@ -34,6 +38,7 @@ talk_5:
   speaker_name: Heller, Yong
   member_id: 30
   meeting_id: 8
+  position: 1
 talk_6:
   id: 6
   purpose: New Ward Member
@@ -41,6 +46,7 @@ talk_6:
   speaker_name: Harris, Staci
   member_id: 24
   meeting_id: 8
+  position: 2
 talk_7:
   id: 7
   purpose: Member Request
@@ -48,6 +54,7 @@ talk_7:
   speaker_name: Aufderhar, Matthew
   member_id: 29
   meeting_id: 8
+  position: 3
 talk_8:
   id: 8
   purpose:
@@ -55,3 +62,4 @@ talk_8:
   speaker_name: Hill, Waylon
   member_id: 4
   meeting_id: 11
+  position: 1


### PR DESCRIPTION
- Adds a `positions` column to the `talks` table
- Adds the `acts_as_list` gem
- Configures the `talk` model to act as a list
- Adds a rake task to add a default position to all talks

Addresses a portion of #81 