### PR TITLE
Add unique index on the talks table for position and meeting_id

### DIFF
--- a/db/migrate/20220619194652_add_unique_position_constraint_to_talks.rb
+++ b/db/migrate/20220619194652_add_unique_position_constraint_to_talks.rb
@@ -1,0 +1,5 @@
+class AddUniquePositionConstraintToTalks < ActiveRecord::Migration[7.0]
+  def change
+    add_index :talks, [:meeting_id, :position], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_19_174712) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_19_194652) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -153,6 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_19_174712) do
     t.bigint "member_id"
     t.bigint "meeting_id"
     t.integer "position"
+    t.index ["meeting_id", "position"], name: "index_talks_on_meeting_id_and_position", unique: true
     t.index ["meeting_id"], name: "index_talks_on_meeting_id"
     t.index ["member_id"], name: "index_talks_on_member_id"
   end


### PR DESCRIPTION
Adds a unique index to the `talks` table on `position` and `meeting_id` to ensure data integrity for position arguments.