### PR TITLE
Use a deferrable constraint to allow position changes

### DIFF
--- a/db/migrate/20220620213858_remove_talks_index_in_favor_of_unique_constraint.rb
+++ b/db/migrate/20220620213858_remove_talks_index_in_favor_of_unique_constraint.rb
@@ -1,0 +1,17 @@
+class RemoveTalksIndexInFavorOfUniqueConstraint < ActiveRecord::Migration[7.0]
+  def up
+    remove_index :talks, [:meeting_id, :position]
+
+    execute <<~SQL
+      alter table talks add constraint unique_meeting_id_position unique (meeting_id, position) deferrable initially deferred;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      alter table talks drop constraint unique_meeting_id_position
+    SQL
+
+    add_index :talks, [:meeting_id, :position], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_19_194652) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_20_213858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_19_194652) do
     t.index ["unit_id", "user_id"], name: "index_access_requests_on_unit_id_and_user_id", unique: true
     t.index ["unit_id"], name: "index_access_requests_on_unit_id"
     t.index ["user_id"], name: "index_access_requests_on_user_id"
+  end
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -153,7 +163,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_19_194652) do
     t.bigint "member_id"
     t.bigint "meeting_id"
     t.integer "position"
-    t.index ["meeting_id", "position"], name: "index_talks_on_meeting_id_and_position", unique: true
+    t.index ["meeting_id", "position"], name: "unique_meeting_id_position", unique: true
     t.index ["meeting_id"], name: "index_talks_on_meeting_id"
     t.index ["member_id"], name: "index_talks_on_member_id"
   end


### PR DESCRIPTION
There is an issue with `acts_as_list` using unique indexes: https://github.com/brendon/acts_as_list/issues/378

Some people recommend using a Postgres constraint instead, and setting that constraint as `deferred` until the transaction has run.

This PR trades out the unique index for a deferred constraint.