### PR TITLE
Import Fixes

### DIFF
--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -40,8 +40,8 @@ class ImportJob < ApplicationRecord
   end
 
   def log!(value)
-    new_logs = "#{logs || ''}#{value}\n"
-    update(logs: new_logs)
+    new_logs = "#{logs}#{value}\n"
+    update_column(:logs, new_logs)
   end
 
   def parsed_errors

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -39,21 +39,28 @@ class ImportJob < ApplicationRecord
     @data_string = raw_data.download
   end
 
+  # A regular update with callbacks will wipe out errors on the ImportJob object.
+  # Use update_column to keep errors intact.
   def log!(value)
     new_logs = "#{logs}#{value}\n"
     update_column(:logs, new_logs)
   end
 
+  # @return [Array[<String>]]
   def parsed_errors
     JSON.parse(error_message || "[\"None\"]")
   end
 
+  # A regular update with callbacks will wipe out errors on the ImportJob object.
+  # Use update_column to keep errors intact.
   def set_elapsed_time!
     return unless persisted? && started_at.present?
 
     update_column(:elapsed_seconds, ::Time.current - started_at)
   end
 
+  # A regular update with callbacks will wipe out errors on the ImportJob object.
+  # Use update_column to keep errors intact.
   def start!
     update_column(:started_at, ::Time.current)
   end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -51,10 +51,10 @@ class ImportJob < ApplicationRecord
   def set_elapsed_time!
     return unless persisted? && started_at.present?
 
-    update_column(:elapsed_seconds, Time.current - started_at)
+    update_column(:elapsed_seconds, ::Time.current - started_at)
   end
 
   def start!
-    update(started_at: ::Time.current)
+    update_column(:started_at, ::Time.current)
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -9,7 +9,6 @@ class Member < ApplicationRecord
 
   validates :name, :gender, :birthdate, presence: true
   validates :name, uniqueness: { scope: :birthdate }, if: :name?
-  validates :phone_number, phone: { allow_blank: true }
   validate :validate_age
 
   strip_attributes

--- a/lib/edify/etl/import_manager.rb
+++ b/lib/edify/etl/import_manager.rb
@@ -3,6 +3,11 @@
 module Edify
   module Etl
     class ImportManager
+      GENDER_MAP = {
+        "f" => "female",
+        "m" => "male",
+      }.freeze
+
       def self.perform!(import_job)
         new(import_job).perform!
       end
@@ -44,7 +49,8 @@ module Edify
             name: raw_member_row.name,
             birthdate: raw_member_row.birthdate
           )
-          raw_member_row.gender = raw_member_row.gender.downcase == "f" ? "female" : "male"
+          gender_indicator = raw_member_row.gender&.downcase&.first
+          raw_member_row.gender = GENDER_MAP[gender_indicator]
           member.assign_attributes(raw_member_row.to_h)
           member.synced_on = Date.current
 

--- a/lib/edify/etl/import_manager.rb
+++ b/lib/edify/etl/import_manager.rb
@@ -13,7 +13,7 @@ module Edify
       end
 
       def perform!
-        import_job.start!
+        start_import_job
         extract_member_list
         save_members if errors.empty?
         set_finish_attributes
@@ -25,6 +25,11 @@ module Edify
       attr_accessor :raw_member_rows
 
       delegate :errors, to: :import_job, private: true
+
+      def start_import_job
+        import_job.start!
+        import_job.touch
+      end
 
       def extract_member_list
         self.raw_member_rows = ExtractMemberData.perform(import_job)

--- a/spec/fixtures/files/raw_member_list.txt
+++ b/spec/fixtures/files/raw_member_list.txt
@@ -23,7 +23,7 @@ Show
 	Bins, Froederick	M	79	22 Feb 1943	(801) 545-4545	froederick@frank.com
 	* Bode, Yolanda	F	12	3 Jun 2009	801 232-3232
 	*Jiminy, Theophilus	M	14	5 Jun 2007	801 876-6654
-	Cummerata, Lisette	F	42	19 Sep 1979	801-549-8877	lisette@cummerata.com
+	Cummerata, Lisette	F	42	19 Sep 1979	07710587623	lisette@cummerata.com
 	King, Amelia Kalā’auolaniwao	F	7	10 Apr 2014	801 898-8989
 	Heidenrick, Kenneth	M	58	1 Jul 1963	385-348-3585	heidenrick@kenneth.com
 Count: 6

--- a/spec/fixtures/files/raw_member_list_filtered.txt
+++ b/spec/fixtures/files/raw_member_list_filtered.txt
@@ -1,0 +1,30 @@
+
+Membership
+Organizations
+Reports
+Ministering
+Finance
+Applications
+Other
+Help
+
+Provo Utah Oak Hills Stake (509078) Oak Hills 5th Ward (79448)
+
+Member List
+
+Print
+
+Individuals
+Households
+
+Show
+
+	Name	Gender	Age	Birth Date	Phone Number	E-mail
+	Bins, Froederick	M	79	22 Feb 1943	(801) 545-4545	froederick@frank.com
+	* Bode, Yolanda	F	12	3 Jun 2009	801 232-3232
+	Cummerata, Lisette	F	42	19 Sep 1979	801-549-8877	lisette@cummerata.com
+Count: 4 (filtered from 10 total)
+* Unbaptized members of record age 9 and over and those baptized but not confirmed are not included in unit statistics or Quarterly Reports.
+  Send Feedback
+
+Contact Us

--- a/spec/lib/edify/etl/extract_member_data_spec.rb
+++ b/spec/lib/edify/etl/extract_member_data_spec.rb
@@ -12,75 +12,86 @@ describe ::Edify::Etl::ExtractMemberData do
   describe "#perform" do
     let(:result) { subject.perform }
 
-    context "when a valid raw_data file is attached" do
+    context "when a raw_data file is attached" do
       before do
-        import_job.raw_data.attach(io: File.open(file_fixture("raw_member_list.txt")),
+        import_job.raw_data.attach(io: File.open(file_fixture(raw_data_file_name)),
                                    filename: "raw_data.txt",
                                    content_type: "text/plain")
       end
 
-      it "returns raw member rows" do
-        expect(result.count).to eq(6)
-        expect(result).to all be_a(::Edify::Etl::RawMemberRow)
+      context "when all data is valid" do
+        let(:raw_data_file_name) { "raw_member_list.txt" }
 
-        expect(result.first.name).to eq("Bins, Froederick")
-        expect(result.first.gender).to eq("M")
-        expect(result.first.birthdate.to_date).to eq("1943-02-22".to_date)
-        expect(result.first.phone_number).to eq("(801) 545-4545")
-        expect(result.first.email).to eq("froederick@frank.com")
+        it "returns raw member rows" do
+          expect(result.count).to eq(6)
+          expect(result).to all be_a(::Edify::Etl::RawMemberRow)
 
-        expect(result.last.name).to eq("Heidenrick, Kenneth")
-        expect(result.last.gender).to eq("M")
-        expect(result.last.birthdate.to_date).to eq("1963-07-01".to_date)
-        expect(result.last.phone_number).to eq("385-348-3585")
-        expect(result.last.email).to eq("heidenrick@kenneth.com")
+          expect(result.first.name).to eq("Bins, Froederick")
+          expect(result.first.gender).to eq("M")
+          expect(result.first.birthdate.to_date).to eq("1943-02-22".to_date)
+          expect(result.first.phone_number).to eq("(801) 545-4545")
+          expect(result.first.email).to eq("froederick@frank.com")
+
+          expect(result.last.name).to eq("Heidenrick, Kenneth")
+          expect(result.last.gender).to eq("M")
+          expect(result.last.birthdate.to_date).to eq("1963-07-01".to_date)
+          expect(result.last.phone_number).to eq("385-348-3585")
+          expect(result.last.email).to eq("heidenrick@kenneth.com")
+        end
+
+        it "removes unbaptized member of record indicators" do
+          expect(result.second.name).to eq("Bode, Yolanda")
+          expect(result.third.name).to eq("Jiminy, Theophilus")
+        end
       end
 
-      it "removes unbaptized member of record indicators" do
-        expect(result.second.name).to eq("Bode, Yolanda")
-        expect(result.third.name).to eq("Jiminy, Theophilus")
+      context "when the raw member data is incomplete" do
+        let(:raw_data_file_name) { "raw_member_list_incomplete.txt" }
+
+        it "returns an empty array" do
+          expect(result).to eq([])
+        end
+
+        it "adds a descriptive error" do
+          expected_string = "Raw data could not be parsed. Please ensure you have copy/pasted the entire member list."
+          subject.perform
+          expect(import_job.errors).to be_present
+          expect(import_job.errors.full_messages).to include(expected_string)
+        end
+      end
+
+      context "when the raw member data has been filtered" do
+        let(:raw_data_file_name) { "raw_member_list_filtered.txt" }
+
+        it "returns an empty array" do
+          expect(result).to eq([])
+        end
+
+        it "adds a descriptive error" do
+          expected_string = "Raw data has been filtered. Please ensure you have scrolled to the bottom of the member list before copying."
+          subject.perform
+          expect(import_job.errors).to be_present
+          expect(import_job.errors.full_messages).to include(expected_string)
+        end
+      end
+
+      context "when headers are not as expected" do
+        let(:raw_data_file_name) { "raw_member_list_bad_headers.txt" }
+
+        it "returns an empty array" do
+          expect(result).to eq([])
+        end
+
+        it "adds a descriptive error" do
+          subject.perform
+          expect(import_job.errors).to be_present
+          expect(import_job.errors.full_messages).to include(/Raw data did not contain expected header Birth Date/)
+          expect(import_job.errors.full_messages).to include(/Raw data did not contain expected header E-mail/)
+        end
       end
     end
 
-    context "when the raw member data is incomplete" do
-      before do
-        import_job.raw_data.attach(io: File.open(file_fixture("raw_member_list_incomplete.txt")),
-                                   filename: "raw_data.txt",
-                                   content_type: "text/plain")
-      end
-
-      it "returns an empty array" do
-        expect(result).to eq([])
-      end
-
-      it "adds a descriptive error" do
-        expected_string = "Raw data could not be parsed. Please ensure you have copy/pasted the entire member list."
-        subject.perform
-        expect(import_job.errors).to be_present
-        expect(import_job.errors.full_messages).to include(expected_string)
-      end
-    end
-
-    context "when headers are not as expected" do
-      before do
-        import_job.raw_data.attach(io: File.open(file_fixture("raw_member_list_bad_headers.txt")),
-                                   filename: "raw_data.txt",
-                                   content_type: "text/plain")
-      end
-
-      it "returns an empty array" do
-        expect(result).to eq([])
-      end
-
-      it "adds a descriptive error" do
-        subject.perform
-        expect(import_job.errors).to be_present
-        expect(import_job.errors.full_messages).to include(/Raw data did not contain expected header Birth Date/)
-        expect(import_job.errors.full_messages).to include(/Raw data did not contain expected header E-mail/)
-      end
-    end
-
-    context "when no raw_data file is attached" do
+    context "when no raw data file is attached" do
       it "returns an empty array" do
         expect(result).to eq([])
       end

--- a/spec/lib/edify/etl/extract_member_data_spec.rb
+++ b/spec/lib/edify/etl/extract_member_data_spec.rb
@@ -43,6 +43,11 @@ describe ::Edify::Etl::ExtractMemberData do
           expect(result.second.name).to eq("Bode, Yolanda")
           expect(result.third.name).to eq("Jiminy, Theophilus")
         end
+
+        it "handles international phone numbers" do
+          expect(result.fourth.name).to eq("Cummerata, Lisette")
+          expect(result.fourth.phone_number).to eq("07710587623")
+        end
       end
 
       context "when the raw member data is incomplete" do

--- a/spec/lib/edify/etl/import_manager_spec.rb
+++ b/spec/lib/edify/etl/import_manager_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "edify/etl"
+
+describe ::Edify::Etl::ImportManager do
+  subject { described_class.new(import_job) }
+
+  let(:unit) { units(:sunny_hills) }
+  let(:import_job) { unit.import_jobs.create!(status: :waiting) }
+  let(:raw_member_rows) do
+    [
+      ::Edify::Etl::RawMemberRow.new(:name => "Bins, Froederick", :gender => "M", :birthdate => "22 Feb 1943", :phone_number => "(801) 545-4545", :email => "froederick@frank.com"),
+      ::Edify::Etl::RawMemberRow.new(:name => "Cummerata, Lisette", :gender => "F", :birthdate => "19 Sep 1979", :phone_number => "07710587623", :email => "lisette@cummerata.com"),
+      ::Edify::Etl::RawMemberRow.new(:name => "Heidenrick, Kenneth", :gender => "M", :birthdate => "1 Jul 1963", :phone_number => "385-348-3585", :email => "heidenrick@kenneth.com"),
+    ]
+  end
+
+  before { allow(::Edify::Etl::ExtractMemberData).to receive(:perform).and_return(raw_member_rows) }
+
+  describe "#perform!" do
+    context "when all member rows are valid" do
+      it "saves members" do
+        expect { subject.perform! }.to change(::Member, :count).by(3)
+      end
+
+      it "does not set an error message" do
+        subject.perform!
+        expect(import_job.error_message).to be_nil
+      end
+
+      it "sets import job attributes as expected" do
+        subject.perform!
+        expect(import_job.succeeded_count).to eq(3)
+        expect(import_job.failed_count).to eq(0)
+        expect(import_job.ignored_count).to eq(0)
+        expect(import_job.status).to eq("finished")
+      end
+    end
+
+    context "when a member row cannot be saved" do
+      let(:raw_member_rows) do
+        [
+          ::Edify::Etl::RawMemberRow.new(:name => "Bins, Froederick", :gender => "M", :birthdate => "22 Feb 1943", :phone_number => "(801) 545-4545", :email => "froederick@frank.com"),
+          ::Edify::Etl::RawMemberRow.new(:name => nil, :gender => "F", :birthdate => "19 Sep 1979", :phone_number => "07710587623", :email => "lisette@cummerata.com"),
+          ::Edify::Etl::RawMemberRow.new(:name => "Heidenrick, Kenneth", :gender => "M", :birthdate => "1 Jul 1963", :phone_number => "385-348-3585", :email => "heidenrick@kenneth.com"),
+        ]
+      end
+
+      it "saves the other members" do
+        expect { subject.perform! }.to change(::Member, :count).by(2)
+      end
+
+      it "sets an error message" do
+        subject.perform!
+        expect(import_job.parsed_errors.count).to eq(1)
+      end
+
+      it "sets import job attributes as expected" do
+        subject.perform!
+        expect(import_job.succeeded_count).to eq(2)
+        expect(import_job.failed_count).to eq(1)
+        expect(import_job.ignored_count).to eq(0)
+        expect(import_job.status).to eq("failed")
+      end
+    end
+
+    context "when no member rows are extracted" do
+      let(:raw_member_rows) { [] }
+
+      it "does not save any members" do
+        expect { subject.perform! }.not_to change(::Member, :count)
+      end
+
+      it "does not set any error message" do
+        subject.perform!
+        expect(import_job.error_message).to be_nil
+      end
+
+      it "sets import job attributes as expected" do
+        subject.perform!
+        expect(import_job.succeeded_count).to eq(0)
+        expect(import_job.failed_count).to eq(0)
+        expect(import_job.ignored_count).to eq(0)
+        expect(import_job.status).to eq("finished")
+      end
+    end
+
+    context "when the import job has errors" do
+      before { import_job.errors.add(:base, "Extraction error at row 2") }
+
+      it "does not attempt to save members" do
+        expect { subject.perform! }.not_to change(::Member, :count)
+      end
+
+      it "sets the error message on the import job" do
+        subject.perform!
+        expect(import_job.parsed_errors).to eq(["Extraction error at row 2"])
+      end
+
+      it "sets import job attributes as expected" do
+        subject.perform!
+        expect(import_job.succeeded_count).to eq(0)
+        expect(import_job.failed_count).to eq(0)
+        expect(import_job.ignored_count).to eq(0)
+        expect(import_job.status).to eq("failed")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We currently have a few problems with member list importing, namely:
- Import jobs are not failing as expected when the list is incomplete
- Error messages are not being saved when the import job has trouble saving a row

This PR updates logic to use `update_column` instead of `update` to keep errors from being wiped out. It also removes the phone validation on the Member model, since it isn't important that those phone numbers be valid.

Addresses #100 and #112