### PR TITLE
Copy song titles to clipboard

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,9 +1,27 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ["source"]
+    static targets = ["button", "source"]
 
     copy() {
         navigator.clipboard.writeText(this.sourceTarget.innerText)
+        this.flashButton()
+    }
+
+    flashButton() {
+        const button = this.buttonTarget;
+        const icon = button.querySelector("i")
+
+        button.classList.add("btn-primary")
+        button.classList.remove("btn-outline-primary")
+        icon.classList.add("fa-clipboard-check")
+        icon.classList.remove("fa-clipboard")
+
+        setTimeout(() => {
+            button.classList.remove("btn-primary")
+            button.classList.add("btn-outline-primary")
+            icon.classList.remove("fa-clipboard-check")
+            icon.classList.add("fa-clipboard")
+        }, 600)
     }
 }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["source"]
+
+    copy() {
+        navigator.clipboard.writeText(this.sourceTarget.innerText)
+    }
+}

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -6,12 +6,13 @@
     <div class="col-12 col-md-6 pt-md-2" data-controller="clipboard">
       <h6>
         <span data-clipboard-target="source"><%= song.title %></span>
-        <span><%= button_tag(fa_icon("clipboard"),
-                             class: "btn btn-sm btn-outline-primary ms-1",
-                             style: "font-size: 0.7em;",
-                             title: "Copy to clipboard",
-                             data: { action: "clipboard#copy", "bs-toggle": "tooltip" })
-        %></span>
+        <span>
+          <%= button_tag(fa_icon("clipboard"),
+                         class: "btn btn-sm btn-outline-primary ms-1",
+                         style: "font-size: 0.7em;",
+                         title: "Copy to clipboard",
+                         data: { action: "clipboard#copy", clipboard_target: "button", bs_toggle: "tooltip" }) %>
+        </span>
       </h6>
     </div>
     <% if current_user.music_editor? %>

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -3,8 +3,11 @@
     <div class="col-12 col-md-4 pt-md-2">
       <h6><%= song.song_type.titleize %></h6>
     </div>
-    <div class="col-12 col-md-6 pt-md-2">
-      <h6><%= song.title %></h6>
+    <div class="col-12 col-md-6 pt-md-2" data-controller="clipboard">
+      <h6>
+        <span data-clipboard-target="source"><%= song.title %></span>
+        <span><%= button_tag(fa_icon("clipboard"), class: "btn btn-sm btn-outline-primary ms-1", style: "font-size: 0.7em;", data: { action: "clipboard#copy" }) %></span>
+      </h6>
     </div>
     <% if current_user.music_editor? %>
       <div class="col-12 col-md-2 text-md-end">

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -6,7 +6,12 @@
     <div class="col-12 col-md-6 pt-md-2" data-controller="clipboard">
       <h6>
         <span data-clipboard-target="source"><%= song.title %></span>
-        <span><%= button_tag(fa_icon("clipboard"), class: "btn btn-sm btn-outline-primary ms-1", style: "font-size: 0.7em;", data: { action: "clipboard#copy" }) %></span>
+        <span><%= button_tag(fa_icon("clipboard"),
+                             class: "btn btn-sm btn-outline-primary ms-1",
+                             style: "font-size: 0.7em;",
+                             title: "Copy to clipboard",
+                             data: { action: "clipboard#copy", "bs-toggle": "tooltip" })
+        %></span>
       </h6>
     </div>
     <% if current_user.music_editor? %>


### PR DESCRIPTION
This PR adds an icon to copy a song title to the clipboard, making it a bit easier to copy/paste into a program.

Resolves #111 

![Screen Shot 2022-08-09 at 9 25 01 PM](https://user-images.githubusercontent.com/14797300/183805559-62f7ce89-8d65-4687-a530-87ee908f5953.png)
![Screen Shot 2022-08-09 at 9 25 10 PM](https://user-images.githubusercontent.com/14797300/183805565-23174561-911c-4fee-9938-538a13125b3a.png)
