### PR TITLE
Revert to Redis 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 7.0.2", ">= 7.0.2.3"
 gem "bootsnap", require: false
 gem "pg"
 gem "puma", "< 6" # Remove this constraint when Capybara has been updated for compatibility with Puma 6
-gem "redis"
+gem "redis", "< 5"
 gem "sprockets-rails"
 gem "stimulus-rails"
 gem "turbo-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,10 +267,7 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
-    redis (5.0.5)
-      redis-client (>= 0.9.0)
-    redis-client (0.10.0)
-      connection_pool
+    redis (4.8.0)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -325,10 +322,10 @@ GEM
       websocket (~> 1.0)
     sendgrid-ruby (6.6.2)
       ruby_http_client (~> 3.4)
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
       rack (~> 2.0)
-      redis (>= 4.5.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.8.0)
       fugit (~> 1)
       sidekiq (>= 4.2.1)
@@ -414,7 +411,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.0.2, >= 7.0.2.3)
   ransack
-  redis
+  redis (< 5)
   responders
   rspec-rails
   rubocop-rails


### PR DESCRIPTION
Sidekiq jobs are not running, possibly as a result of the upgrade from Redis 4 to Redis 5.

This PR reverts to Redis 4.