### PR TITLE
Use a case-insensitive search for existing member emails

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -18,7 +18,7 @@ class AccessRequestsController < ApplicationController
     @unit = Unit.find_by(name: unit_name_param)
 
     if @unit.present?
-      if @unit.members.exists?(email: current_user.email)
+      if @unit.members.where("email ilike ?", current_user.email).exists?
         @unit.access_requests.create(user: current_user)
         ::UnitAccessRequestJob.perform_later(unit: @unit, user: current_user)
 

--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -18,7 +18,7 @@ class AccessRequestsController < ApplicationController
     @unit = Unit.find_by(name: unit_name_param)
 
     if @unit.present?
-      if @unit.members.where("email ilike ?", current_user.email).exists?
+      if @unit.members.exists?(["email ilike ?", current_user.email])
         @unit.access_requests.create(user: current_user)
         ::UnitAccessRequestJob.perform_later(unit: @unit, user: current_user)
 


### PR DESCRIPTION
Currently, if a user signs up using a valid church email address but the case does not match, the access request will not be created.

This PR uses a case-insensitive search to avoid this problem.