### PR TITLE
Fix the admin impersonate feature

### DIFF
--- a/app/madmin/resources/user_resource.rb
+++ b/app/madmin/resources/user_resource.rb
@@ -24,6 +24,10 @@ class UserResource < Madmin::Resource
   attribute :scheduled_meetings
   attribute :unit
 
+  def self.impersonate_start_path(record)
+    url_helpers.impersonate_start_path(record)
+  end
+
   # Uncomment this to customize the display name of records in the admin area.
   # def self.display_name(record)
   #   record.name

--- a/app/views/madmin/users/show.html.erb
+++ b/app/views/madmin/users/show.html.erb
@@ -7,7 +7,10 @@
 
   <div class="flex items-center px-4">
     <div class="mr-2">
-      <%= link_to "Impersonate", Rails.application.routes.url_helpers.impersonate_start_path(@record), method: :post, class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>
+      <%= link_to "Impersonate",
+        resource.impersonate_start_path(@record),
+        data: { "turbo-method": :post },
+        class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>
     </div>
     <div class="mr-2">
       <%= link_to "Edit", resource.edit_path(@record), class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <% if current_user != true_user %>
   <div class="alert alert-warning text-center">
-    You're logged in as <b><%= current_user.name %> (<%= current_user.email %>)</b>
-    <%= link_to fa_icon("times", text: "Logout"), impersonate_stop_path, method: :post %>
+    <span>You're logged in as <b><%= current_user.name %> (<%= current_user.email %>)</b></span>
+    <span class="px-2"><%= link_to "Stop impersonating", impersonate_stop_path, method: :post, class: "btn btn-sm btn-outline-danger" %></span>
   </div>
 <% end %>
 


### PR DESCRIPTION
The impersonate button on the admin screen is returning 404 because clicking the button results in a GET when the route expects a POST. 

This PR fixes the problem by using the new `turbo-method` attribute.