### PR TITLE
Register custom selenium drivers

### DIFF
--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-# Noel Rappin at https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
-
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
 
-  config.before(:each, js: true, type: :system) do
-    driven_by :selenium_chrome_headless
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
   end
 end

--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
-  config.before(:each, type: :system, js: true) do
+  config.before(:each, js: true, type: :system) do
     driven_by :chrome_headless
   end
 end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# chrome_headless is the default driver for system tests
+Capybara.register_driver :chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[headless disable-gpu no-sandbox window-size=1024,768],
+    )
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 clear_session_storage: true,
+                                 clear_local_storage: true,
+                                 options: options
+end
+
+# chrome_visible can be used for debugging by changing the argument
+# passed to `driven_by` in spec/support/basic_configure.rb from
+# :chrome_headless to :chrome_visible
+Capybara.register_driver :chrome_visible do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[disable-gpu no-sandbox window-size=1024,768],
+  )
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 clear_session_storage: true,
+                                 clear_local_storage: true,
+                                 options: options
+end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -4,7 +4,7 @@
 Capybara.register_driver :chrome_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless disable-gpu no-sandbox window-size=1024,768],
-    )
+  )
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
                                  clear_session_storage: true,

--- a/spec/system/user_access_approval_spec.rb
+++ b/spec/system/user_access_approval_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Handle access request by a new user" do
+describe "Handle access request by a new user", js: true do
   let(:reviewing_user) { users(:sunny_bishopric) }
   let(:requesting_user) { users(:unassigned) }
   let(:access_request) { requesting_user.access_request }
@@ -41,25 +41,21 @@ describe "Handle access request by a new user" do
     end
   end
 
-  context "when access is rejected" do
-    before { driven_by :selenium_chrome_headless }
+  scenario "Access request is rejected" do
+    login_as reviewing_user, scope: :user
+    navigate_to_review_screen
 
-    scenario "Access request is rejected" do
-      login_as reviewing_user, scope: :user
-      navigate_to_review_screen
-
-      accept_alert do
-        click_link("Reject")
-      end
-
-      expect(page).to have_current_path(users_path)
-      requesting_user.reload
-      expect(requesting_user.unit).to be_nil
-      expect(requesting_user.role).to be_nil
-
-      access_request.reload
-      expect(access_request).to be_rejected
+    accept_alert do
+      click_link("Reject")
     end
+
+    expect(page).to have_current_path(users_path)
+    requesting_user.reload
+    expect(requesting_user.unit).to be_nil
+    expect(requesting_user.role).to be_nil
+
+    access_request.reload
+    expect(access_request).to be_rejected
   end
 
   def navigate_to_review_screen


### PR DESCRIPTION
This PR introduces custom selenium drivers to get rid of deprecation warnings raised by the Capybara standard drivers.