### PR TITLE
Remove unnecessary keyword_init

### DIFF
--- a/lib/edify/etl/extract_member_data.rb
+++ b/lib/edify/etl/extract_member_data.rb
@@ -85,7 +85,7 @@ module Edify
           attributes = row.to_h.slice(*included_attributes)
           next if attributes.compact.empty?
 
-          raw_member_row = RawMemberRow.new(attributes)
+          raw_member_row = RawMemberRow.new(**attributes)
 
           strip_unbaptized_member_of_record(raw_member_row)
 
@@ -100,6 +100,9 @@ module Edify
       end
 
       def included_attributes
+        # Struct#members returns an array of symbols representing the attributes of the Struct,
+        # e.g., [:name, :gender, :birthdate], similar to calling `.to_h.keys` on the Struct.
+        # It has nothing to do with the Member model
         @included_attributes ||= RawMemberRow.members.map(&:to_s)
       end
 

--- a/lib/edify/etl/raw_member_row.rb
+++ b/lib/edify/etl/raw_member_row.rb
@@ -2,6 +2,6 @@
 
 module Edify
   module Etl
-    RawMemberRow = Struct.new(:name, :gender, :birthdate, :phone_number, :email, keyword_init: true)
+    RawMemberRow = Struct.new(:name, :gender, :birthdate, :phone_number, :email)
   end
 end


### PR DESCRIPTION
Since Ruby 3.2, we no longer need to use `keyword_init: true` to enable keyword initialization for a Struct. But if we remove it, we need to splat out the arguments to specify that the hash is not being assigned to the first argument.

This PR modernizes `RawMemberRow` to use the new syntax.