### PR TITLE
Add owner to import jobs

### DIFF
--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ImportJob < ApplicationRecord
+  belongs_to :owner, class_name: "User", optional: true
   belongs_to :unit
   has_one_attached :raw_data
   broadcasts_to :unit, inserts_by: :prepend
@@ -20,8 +21,6 @@ class ImportJob < ApplicationRecord
     finished: 4,
     failed: 5
   }
-
-  alias_attribute :owner_id, :user_id
 
   def data_string=(string)
     @data_string = string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
     program: 4,
   }
 
+  has_many :import_jobs, foreign_key: :owner_id, dependent: :nullify
   has_many :scheduled_meetings, class_name: "Meeting", foreign_key: :scheduler_id, dependent: :nullify
   has_many :notifications, as: :recipient, dependent: :destroy
   has_one :access_request, dependent: :destroy

--- a/db/migrate/20230307031239_add_owner_id_to_import_jobs.rb
+++ b/db/migrate/20230307031239_add_owner_id_to_import_jobs.rb
@@ -1,0 +1,5 @@
+class AddOwnerIdToImportJobs < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :import_jobs, :owner, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_25_033221) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_031239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,6 +101,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_25_033221) do
     t.string "logs"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "owner_id"
+    t.index ["owner_id"], name: "index_import_jobs_on_owner_id"
     t.index ["unit_id"], name: "index_import_jobs_on_unit_id"
   end
 
@@ -215,6 +217,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_25_033221) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "import_jobs", "units"
+  add_foreign_key "import_jobs", "users", column: "owner_id"
   add_foreign_key "meetings", "units"
   add_foreign_key "meetings", "users", column: "scheduler_id"
   add_foreign_key "members", "units"


### PR DESCRIPTION
It would be useful to persist the user id of the person running an import job.

This PR adds an `owner_id` column to the `import_jobs` table and sets up the model relationships.