### PR TITLE
Migration to add program members to meetings

### DIFF
--- a/db/migrate/20230813164610_add_program_members_to_meetings.rb
+++ b/db/migrate/20230813164610_add_program_members_to_meetings.rb
@@ -1,0 +1,8 @@
+class AddProgramMembersToMeetings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :meetings, :presider_name, :string
+    add_column :meetings, :conductor_name, :string
+    add_column :meetings, :chorister_name, :string
+    add_column :meetings, :organist_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_052429) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_13_164610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,6 +113,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_052429) do
     t.datetime "updated_at", null: false
     t.bigint "unit_id"
     t.bigint "scheduler_id"
+    t.string "presider_name"
+    t.string "conductor_name"
+    t.string "chorister_name"
+    t.string "organist_name"
     t.index ["date", "unit_id"], name: "index_meetings_on_date_and_unit_id", unique: true
     t.index ["scheduler_id"], name: "index_meetings_on_scheduler_id"
     t.index ["unit_id"], name: "index_meetings_on_unit_id"


### PR DESCRIPTION
This PR contains a migration that adds the following fields to the `meetings` table:
- `presider_name`
- `conductor_name`
- `chorister_name`
- `organist_name`

These are simple strings instead of relations to the `members` table, because members may leave the ward but we want to retain the names of those who performed these duties.