### PR TITLE
Opening and closing prayers in contributors

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -131,6 +131,6 @@ class MeetingsController < ApplicationController
   end
 
   def meeting_program_member_params
-    params.require(:meeting).permit(*Meeting::PROGRAM_MEMBER_TITLES)
+    params.require(:meeting).permit(*Meeting::PROGRAM_MEMBER_TITLES.keys)
   end
 end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -131,6 +131,6 @@ class MeetingsController < ApplicationController
   end
 
   def meeting_program_member_params
-    params.require(:meeting).permit(*Meeting::PROGRAM_MEMBER_TITLES.keys)
+    params.require(:meeting).permit(*Meeting::CONTRIBUTOR_TITLES.keys)
   end
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Meeting < ApplicationRecord
-  PROGRAM_MEMBER_TITLES = {
+  CONTRIBUTOR_TITLES = {
     presider_name: "Presiding",
     conductor_name: "Conducting",
     chorister_name: "Chorister",
     organist_name: "Organist",
+    opening_prayer_name: "Opening Prayer",
+    closing_prayer_name: "Closing Prayer",
   }.freeze
 
   has_many :talks, -> { order(position: :asc) }, dependent: nil

--- a/app/views/meetings/_contributors.html.erb
+++ b/app/views/meetings/_contributors.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (meeting:) %>
 
 <%= turbo_frame_tag dom_id(meeting, :contributors) do %>
-  <% Meeting::PROGRAM_MEMBER_TITLES.each do |attribute, display_name| %>
+  <% Meeting::CONTRIBUTOR_TITLES.each do |attribute, display_name| %>
     <%= turbo_frame_tag dom_id(meeting, "contributors_#{attribute}") do %>
       <div class="row">
         <div class="col-12 col-md-4 pt-md-2">

--- a/app/views/meetings/edit_contributors.html.erb
+++ b/app/views/meetings/edit_contributors.html.erb
@@ -1,4 +1,4 @@
-<% Meeting::PROGRAM_MEMBER_TITLES.each do |attribute, display_name| %>
+<% Meeting::CONTRIBUTOR_TITLES.each do |attribute, display_name| %>
   <%= turbo_frame_tag dom_id(@meeting, "contributors_#{attribute}") do %>
     <% form_with model: @meeting,
                  url: update_contributors_meeting_path(@meeting),


### PR DESCRIPTION
This PR adds opening and closing prayers in the Contributors tab.

It also fixes a bug in the permitted params for contributors and renames `PROGRAM_MEMBER_TITLES` to `CONTRIBUTOR_TITLES`.