### PR TITLE
Spreadsheet-style music view

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -7,13 +7,11 @@ class MeetingsController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_user
   before_action :set_meeting, only: %i[show edit update destroy edit_contributors update_contributors]
+  before_action :set_meetings_and_pagy, only: %i[index music]
   after_action :verify_authorized
 
   # GET /meetings
   def index
-    @q = current_unit.meetings.ransack(params[:q])
-    @q.sorts = ["date desc"] if @q.sorts.empty?
-    @pagy, @meetings = pagy(@q.result.includes(:talks))
     @meetings_view_object = ::MeetingsViewObject.new(@meetings, view_context, @pagy)
   end
 
@@ -100,6 +98,11 @@ class MeetingsController < ApplicationController
     end
   end
 
+  # GET /meetings/music
+  def music
+    @meetings_view_object = ::MeetingsViewObject.new(@meetings, view_context, @pagy)
+  end
+
   # POST /meetings/upsert
   # This is an upsert using date as a unique key
   def upsert
@@ -122,6 +125,12 @@ class MeetingsController < ApplicationController
   end
 
   private
+
+  def set_meetings_and_pagy
+    @q = current_unit.meetings.ransack(params[:q])
+    @q.sorts = ["date desc"] if @q.sorts.empty?
+    @pagy, @meetings = pagy(@q.result.includes(:talks, :songs))
+  end
 
   def set_meeting
     @meeting = current_unit.meetings.find(params[:id])

--- a/app/helpers/meetings_helper.rb
+++ b/app/helpers/meetings_helper.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 module MeetingsHelper
+  def badge_for_meeting_type(meeting_type)
+    text = meeting_badge_attributes.dig(meeting_type, :text)
+    color = meeting_badge_attributes.dig(meeting_type, :color)
+
+    content_tag(:span, text, class: ["badge", "bg-#{color}"].join(" "), data: { "bs-toggle" => "tooltip" }, title: meeting_type.titleize)
+  end
+
+  def meeting_badge_attributes
+    {
+      sacrament_meeting: { text: "SM", color: "success" },
+      testimony_meeting: { text: "TM", color: "secondary" },
+      ward_conference: { text: "WC", color: "success" },
+      stake_conference: { text: "SC", color: "info" },
+      general_conference: { text: "GC", color: "primary" },
+      primary_program: { text: "PP", color: "info" },
+      musical_testimony: { text: "MT", color: "secondary" }
+    }.with_indifferent_access.freeze
+  end
+
   def select_options_for_meeting_scheduler(meeting)
     users = current_unit.users.where.not(id: current_user.id).to_a
     users.unshift(current_user)

--- a/app/helpers/meetings_helper.rb
+++ b/app/helpers/meetings_helper.rb
@@ -5,7 +5,13 @@ module MeetingsHelper
     text = meeting_badge_attributes.dig(meeting_type, :text)
     color = meeting_badge_attributes.dig(meeting_type, :color)
 
-    content_tag(:span, text, class: ["badge", "bg-#{color}"].join(" "), data: { "bs-toggle" => "tooltip" }, title: meeting_type.titleize)
+    content_tag(
+      :span,
+      text,
+      class: ["badge", "bg-#{color}"].join(" "),
+      data: { "bs-toggle" => "tooltip" },
+      title: meeting_type.titleize
+    )
   end
 
   def meeting_badge_attributes

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -25,6 +25,10 @@ class MeetingPolicy < ApplicationPolicy
     user.music_editor?
   end
 
+  def music?
+    index?
+  end
+
   def edit_contributors?
     user.present?
   end

--- a/app/views/meetings/music.html.erb
+++ b/app/views/meetings/music.html.erb
@@ -1,0 +1,53 @@
+<div class="row">
+  <div class="col-md">
+    <h2 class="mt-md-4 mt-2"><strong><%= "#{@meetings_view_object.unit_name} Meetings" %></strong></h2>
+  </div>
+  <div class="col-md">
+    <h5 class="mt-md-4 pt-md-3 text-md-end text-muted">
+      <%= filtered_and_total_count(@meetings_view_object.filtered_count, @meetings_view_object.total_count, "meeting") %>
+    </h5>
+  </div>
+</div>
+
+<hr/>
+<br/>
+
+<div class="row">
+  <div class="col-12 col-md-6 col-inline mt-1">
+    <%= filter_meetings_type_dropdown(request.params, label: "Meeting Type") %>
+  </div>
+</div>
+
+<hr/>
+
+<div class="container-fluid table-responsive">
+  <table class="table table-sm table-bordered">
+    <thead>
+    <tr>
+      <th>Date</th>
+      <th>Chorister</th>
+      <th>Organist</th>
+      <th>Opening Hymn</th>
+      <th>Sacrament Hymn</th>
+      <th>Closing Hymn</th>
+      <th>Musical Number</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @meetings_view_object.meetings.each do |meeting| %>
+      <tr>
+        <td class="ps-2 pe-3 text-nowrap">
+          <%= l(meeting.date, format: :rfc822) %>
+          <span class="ps-1"><%= badge_for_meeting_type(meeting.meeting_type) %></span>
+        </td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.chorister_name %></td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.organist_name %></td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "opening_hymn" }&.title %></td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "sacrament_hymn" }&.title %></td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "closing_hymn" }&.title %></td>
+        <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "musical_number" }&.title %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,28 +17,39 @@ Rails.application.routes.draw do
     put :approve, on: :member
     put :reject, on: :member
   end
+
   resources :announcements, only: [:index]
   resources :import_jobs, only: [:index, :show, :new, :create, :destroy]
+
   resources :meetings do
-    get :edit_contributors, on: :member
-    patch :update_contributors, on: :member
-    post :upsert, on: :collection
+    member do
+      get :edit_contributors
+      patch :update_contributors
+    end
+    collection do
+      get :music
+      post :upsert
+    end
     resources :talks, except: :index do
       patch :move, on: :member
       post :upsert, on: :collection
     end
     resources :songs, except: :index
   end
+
   resources :members do
     post :upsert, on: :collection
     resources :notes
   end
+
   resources :notifications, only: [:index]
   resources :talks, only: [:index]
+
   resources :units, only: [:new, :edit, :create, :update] do
     get :song_last_sung, on: :member
     get :speaker_last_spoke, on: :member
   end
+
   resources :users, only: [:index, :show, :edit, :update, :destroy]
 
   namespace :settings do


### PR DESCRIPTION
This PR introduces a spreadsheet-style music view to allow a user to easily scan recently sung hymns and ensure music has been entered for upcoming meetings.