### PR TITLE
Use ransack scopes and sort_url for talks index view

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -10,8 +10,8 @@ class TalksController < ApplicationController
 
   # GET /talks
   def index
-    @q = current_unit.talks.ransack(params[:q])
-    @q.sorts = ["meeting_date desc", "speaker_name asc"] if @q.sorts.empty?
+    # unscope(:order) is needed to remove the position order inserted by acts_as_list
+    @q = current_unit.talks.unscope(:order).sort_by_meeting_date_desc.ransack(params[:q])
     @pagy, @talks = pagy(@q.result.includes(:member, :meeting), items: params[:items])
   end
 

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -180,8 +180,8 @@ module DropdownHelper
     build_dropdown_menu(title, dropdown_items, options)
   end
 
-  def sort_talks_dropdown(request_params, ransack_query, options = {})
-    existing_sort_attribute = ransack_query.sorts.first.name
+  def sort_talks_dropdown(ransack_query, options = {})
+    existing_sort_attribute = ransack_query.sorts.first&.name || "meeting_date"
     title = case existing_sort_attribute
             when "speaker_name"
               "By name"
@@ -193,10 +193,10 @@ module DropdownHelper
 
     dropdown_items = [
       { name: "Date",
-        link: request_params.deep_merge(q: { s: "meeting_date desc" }),
+        link: sort_url(ransack_query, :meeting_date, default_order: :desc),
         active: existing_sort_attribute == "meeting_date" },
       { name: "Name",
-        link: request_params.deep_merge(q: { s: "speaker_name asc" }),
+        link: sort_url(ransack_query, :speaker_name, default_order: :asc),
         active: existing_sort_attribute == "speaker_name" },
     ]
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -21,14 +21,15 @@ class Talk < ApplicationRecord
 
   strip_attributes
 
-  scope :most_recent_first, -> { joins(:meeting).order(date: :desc) }
+  scope :sort_by_meeting_date_asc, -> { joins(:meeting).order("meetings.date asc") }
+  scope :sort_by_meeting_date_desc, -> { joins(:meeting).order("meetings.date desc") }
 
   before_save :match_member
 
   delegate :date, :date?, to: :meeting, allow_nil: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[purpose speaker_name topic]
+    %w[purpose speaker_name topic member_id]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -74,7 +74,7 @@
         </tr>
         </thead>
         <tbody>
-        <% @member.talks.most_recent_first.each do |talk| %>
+        <% @member.talks.sort_by_meeting_date_desc.each do |talk| %>
           <tr>
             <td>
               <%= link_to fa_icon("calendar-alt"), meeting_path(talk.meeting), data: { "bs-toggle" => "tooltip" }, title: "Visit meeting page" %>&nbsp

--- a/app/views/talks/_sort_and_filter_dropdowns.html.erb
+++ b/app/views/talks/_sort_and_filter_dropdowns.html.erb
@@ -1,4 +1,4 @@
 <div id="sort_and_filter_dropdowns">
-  <%= sort_talks_dropdown(request.params, @q, label: "Sort") %>
+  <%= sort_talks_dropdown(@q, label: "Sort") %>
   <%= filter_talks_matched_dropdown(request.params, label: "Matching?") %>
 </div>


### PR DESCRIPTION
Currently, the talks index view is not sorting by meeting date. This is because ransack has not been properly configured for the Talk model.

This PR configures the model, sets up scopes, and uses Ransack's `sort_url` helper method in the view.