### PR TITLE
Fix recurring.yml

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,4 +13,4 @@ production:
   meeting_schedule_notify:
     class: "MeetingScheduleNotifyJob"
     queue: default
-    schedule: at 1500 every day
+    schedule: at 3pm every day


### PR DESCRIPTION
The app is crashing with the following message:

```
2024-12-27T22:20:06.273646+00:00 app[web.1]: Invalid recurring tasks:
2024-12-27T22:20:06.273656+00:00 app[web.1]: - meeting_schedule_notify: Schedule is not a supported recurring schedule
```

This PR changes the schedule to more closely match the one used in the provided example.