### PR TITLE
Reduce queue threads to 1

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: 1
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 


### PR DESCRIPTION
Memory quota is being consistently exceeded. This PR reduces queue threads from 3 to 1 to attempt to bring memory usage under quota.