### PR TITLE
Use kebab case instead of underscore for params["cf-turnstile-response"]

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -34,7 +34,7 @@ module Users
       return unless Rails.env.production?
       return if ::EdifyConfig.cloudflare_turnstile_secret_key.nil?
 
-      token = params[:cf_turnstile_response].to_s
+      token = params["cf-turnstile-response"].to_s
       return if ::Cloudflare::TurnstileVerifier.token_valid?(token)
 
       redirect_to root_path, notice: I18n.t("controllers.registrations_controller.flash.turnstile_unauthorized")


### PR DESCRIPTION
The Cloudflare Turnstile response is coming into the Registrations Controller as `cf-turnstile-response`, where before we were looking for `cf_turnstile_response`. 

This PR grabs the correct param before passing it to `Cloudflare::TurnstileVerifier#token_valid?`.