### PR TITLE
Move solid_queue out of puma and into a separate worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rails server
+worker: bin/jobs -c config/queue.yml
 release: bundle exec rails db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -p 3000
+worker: bin/jobs -c config/queue.yml
 js: yarn build --watch
 css: yarn build:css --watch

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,6 +41,3 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-
-# Run the solid_queue supervisor together with puma when environment variable is set
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 1
+      threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 


### PR DESCRIPTION
Solid queue is taking too much memory in the Puma server, resulting in memory swapping in Heroku. It does not seem possible to run the worker inside of Puma in a 512MB container, even with concurrency at 1 and threads at 1.

This PR moves Solid Queue into a separate worker instance (and sets threads back to 3).