### PR TITLE
Clean-up fixes

### DIFF
--- a/config/initializers/01_edify_config.rb
+++ b/config/initializers/01_edify_config.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class EdifyConfig
-  CLOUDFLARE_TURNSTILE_JS_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js"
-  CLOUDFLARE_TURNSTILE_SITE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
-
   def self.app_url
     ::ENV["APP_URL"] || "localhost:3000"
   end
@@ -17,11 +14,11 @@ class EdifyConfig
   end
 
   def self.cloudflare_turnstile_site_verify_url
-    CLOUDFLARE_TURNSTILE_SITE_VERIFY_URL
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify"
   end
 
   def self.cloudflare_turnstile_js_url
-    CLOUDFLARE_TURNSTILE_JS_URL
+    "https://challenges.cloudflare.com/turnstile/v0/api.js"
   end
 
   def self.email_sender_address

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -12,6 +12,8 @@
 # To test natural language schedule strings run
 # Fugit.parse("my schedule string").original
 
+development: {}
+
 production:
   meeting_schedule_notify:
     class: "MeetingScheduleNotifyJob"


### PR DESCRIPTION
This PR makes two small clean-up fixes:

- Removes constant definitions from the EdifyConfig class. This class gets loaded more than once, and with constant definitions we see re-definition warnings
- Adds an empty `development` key to `recurring.yml`. This allows us to run the worker in development mode