### PR TITLE
Use rake task to start solid_queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server
-worker: bin/jobs -c config/queue.yml
+worker: bundle exec rake solid_queue:start
 release: bundle exec rails db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bin/rails server -p 3000
-worker: bin/jobs -c config/queue.yml
+worker: bundle exec rake solid_queue:start
 js: yarn build --watch
 css: yarn build:css --watch


### PR DESCRIPTION
One user reports increased memory usage when starting solid_queue using `bin/jobs` and lower memory usage when starting it with the included rake task `bundle exec rake solid_queue:start`.

This PR changes to the second method in hopes of reducing memory usage.