### PR TITLE
Add opening and closing prayers to music (grid) view

### DIFF
--- a/app/views/meetings/_meeting_for_music.html.erb
+++ b/app/views/meetings/_meeting_for_music.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (meeting:) %>
+
 <tr>
   <td class="ps-2 pe-3 text-nowrap">
     <%= l(meeting.date, format: :rfc822) %>
@@ -9,4 +11,6 @@
   <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "sacrament_hymn" }&.title %></td>
   <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "closing_hymn" }&.title %></td>
   <td class="ps-2 pe-3 text-nowrap"><%= meeting.songs.find { |song| song.song_type == "musical_number" }&.title %></td>
+  <td class="ps-2 pe-3 text-nowrap"><%= meeting.opening_prayer_name %></td>
+  <td class="ps-2 pe-3 text-nowrap"><%= meeting.closing_prayer_name %></td>
 </tr>

--- a/app/views/meetings/music.html.erb
+++ b/app/views/meetings/music.html.erb
@@ -33,6 +33,8 @@
     <th>Sacrament Hymn</th>
     <th>Closing Hymn</th>
     <th>Musical Number</th>
+    <th>Opening Prayer</th>
+    <th>Closing Prayer</th>
   </tr>
   </thead>
   <tbody id="meetings">


### PR DESCRIPTION
This PR adds "Opening Prayer" and "Closing Prayer" columns to the Music view.

We should consider renaming this the "Grid" view. Also, we should consider making the columns customizable in some way (allowing each to be hidden or shown).