### PR TITLE
SMS opt-in flow

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,10 +18,6 @@
       </div>
 
       <div class="mb-3">
-        <%= f.text_field :phone_number, class: 'form-control', placeholder: "Phone (to receive text messages)" %>
-      </div>
-
-      <div class="mb-3">
         <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password' %>
       </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,19 +10,19 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="mb-3">
-        <%= f.text_field :name, autofocus: true, class: 'form-control', placeholder: "Full name" %>
+        <%= f.text_field :name, autofocus: true, class: "form-control", placeholder: "Full name" %>
       </div>
 
       <div class="mb-3">
-        <%= f.email_field :email, class: 'form-control', placeholder: "Email Address" %>
+        <%= f.email_field :email, class: "form-control", placeholder: "Email address" %>
       </div>
 
       <div class="mb-3">
-        <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password' %>
+        <%= f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "Password" %>
       </div>
 
       <div class="mb-3">
-        <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm Password' %>
+        <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control", placeholder: "Confirm password" %>
       </div>
 
       <div class="mb-3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,11 +4,11 @@
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="mb-3">
-        <%= f.email_field :email, autofocus: true, placeholder: 'Email Address', class: 'form-control' %>
+        <%= f.email_field :email, autofocus: true, placeholder: "Email address", class: "form-control" %>
       </div>
 
       <div class="mb-3">
-        <%= f.password_field :password, autocomplete: "off", placeholder: 'Password', class: 'form-control' %>
+        <%= f.password_field :password, autocomplete: "off", placeholder: "Password", class: "form-control" %>
       </div>
 
       <% if devise_mapping.rememberable? -%>

--- a/spec/system/user_sign_in_spec.rb
+++ b/spec/system/user_sign_in_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "User signs in" do
+  scenario "with correct credentials" do
+    navigate_to_sign_in_page
+
+    within("form") do
+      fill_in "Email address", with: "bishopric@example.com"
+      fill_in "Password", with: "password"
+      click_button "Log in"
+    end
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_text("Signed in successfully.")
+    expect(page).to have_text("Sunny Hills 3rd Ward")
+  end
+
+  scenario "with no credentials" do
+    navigate_to_sign_in_page
+
+    within("form") { click_button "Log in" }
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_text("Invalid Email or password.")
+  end
+
+  scenario "with no password" do
+    navigate_to_sign_in_page
+
+    within("form") do
+      fill_in "Email address", with: "bishopric@example.com"
+      click_button "Log in"
+    end
+
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_text("Invalid Email or password.")
+  end
+
+  scenario "with wrong password" do
+    navigate_to_sign_in_page
+
+    within("form") do
+      fill_in "Email address", with: "bishopric@example.com"
+      fill_in "Password", with: "wrongpassword"
+      click_button "Log in"
+    end
+
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_text("Invalid Email or password.")
+  end
+
+  scenario "with nonexistent email" do
+    navigate_to_sign_in_page
+
+    within("form") do
+      fill_in "Email address", with: "nonexistent@example.com"
+      fill_in "Password", with: "password"
+      click_button "Log in"
+    end
+
+    expect(page).to have_current_path(new_user_session_path)
+    expect(page).to have_text("Invalid Email or password.")
+  end
+
+  def navigate_to_sign_in_page
+    visit root_path
+    click_link "Login"
+    expect(page).to have_current_path(new_user_session_path)
+  end
+end

--- a/spec/system/user_sign_up_spec.rb
+++ b/spec/system/user_sign_up_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe "Visitor signs up" do
+  scenario "with complete and valid information" do
+    navigate_to_sign_up_page
+
+    expect do
+      within("form") do
+        fill_in "Full name", with: "Brand New User"
+        fill_in "Email address", with: "newuser@example.com"
+        fill_in "Password", with: "password"
+        fill_in "Confirm password", with: "password"
+        click_button "Sign up"
+      end
+
+      expect(page).to have_current_path(root_path)
+    end.to change(User, :count).by(1)
+
+    expect(page).to have_content("A message with a confirmation link has been sent to your email address")
+  end
+
+  scenario "with no information" do
+    navigate_to_sign_up_page
+
+    expect do
+      within("form") { click_button "Sign up" }
+    end.not_to change(User, :count)
+
+    expect(page).to have_content("Email can't be blank")
+    expect(page).to have_content("Password can't be blank")
+    expect(page).to have_content("First name can't be blank")
+  end
+
+  scenario "with invalid information" do
+    navigate_to_sign_up_page
+
+    expect do
+      within("form") do
+        fill_in "Full name", with: "Brand New User"
+        fill_in "Email address", with: "newuser"
+        fill_in "Password", with: "password"
+        fill_in "Confirm password", with: "password"
+        click_button "Sign up"
+      end
+    end.not_to change(User, :count)
+
+    expect(page).to have_content("Email is invalid")
+  end
+
+  scenario "with passwords that don't match" do
+    navigate_to_sign_up_page
+
+    expect do
+      within("form") do
+        fill_in "Full name", with: "Brand New User"
+        fill_in "Email address", with: "newuser@example.com"
+        fill_in "Password", with: "password"
+        fill_in "Confirm password", with: "wrongpassword"
+        click_button "Sign up"
+      end
+    end.not_to change(User, :count)
+
+    expect(page).to have_content("Password confirmation doesn't match Password")
+  end
+
+  def navigate_to_sign_up_page
+    visit root_path
+    click_link "Sign Up"
+    expect(page).to have_current_path(new_user_registration_path)
+  end
+end


### PR DESCRIPTION
This PR removes the phone number from the sign-up view and moves all phone and SMS opt-in UI to the User Settings.