### PR TITLE
Run github actions on pull request

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,7 @@
 name: Verify
-on: [ push ]
+on:
+  push:
+  pull_request:
 
 jobs:
   linters:


### PR DESCRIPTION
Currently, we are running actions only on push. This works fine when pushing to the central repo, but it doesn't work for someone creating a PR from a fork.

This PR runs actions on pull_request as well as push.