### PR TITLE
Change outbound email to https over 2525

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,11 +80,11 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: ::EdifyConfig.app_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: ::EdifyConfig.app_url, protocol: "https" }
 
   config.action_mailer.smtp_settings = {
     address: "smtp.sendgrid.net",
-    port: "587",
+    port: "2525",
     authentication: :plain,
     user_name: "apikey",
     password: ::EdifyConfig.sendgrid_api_key,


### PR DESCRIPTION
Currently, we are attempting to send emails using sendgrid via port 587. That port is blocked on digital ocean servers.

Changing to port 2525 should fix this problem. 

Also, we are currently using `http` but should be using `https`.