### PR TITLE
Add Mailgun webhook endpoint for email event tracking

### DIFF
--- a/app/controllers/webhooks/mailgun_events_controller.rb
+++ b/app/controllers/webhooks/mailgun_events_controller.rb
@@ -1,0 +1,44 @@
+module Webhooks
+  class MailgunEventsController < ::ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def create
+      return head :unauthorized unless valid_signature?
+
+      event_data = params.require(:event_data)
+
+      mailgun_event = Analytics::MailgunEvent.new(
+        recipient: event_data[:recipient],
+        timestamp: event_data[:timestamp],
+        event: event_data[:event],
+        mailgun_event_id: event_data[:id],
+        mailgun_message_id: event_data.dig(:message, :headers, :message_id),
+        ip: event_data[:ip],
+        reason: event_data[:reason],
+        status: event_data.dig(:delivery_status, :code)&.to_s,
+        response: event_data.dig(:delivery_status, :message),
+        useragent: event_data.dig(:client_info, :user_agent),
+      )
+
+      if mailgun_event.save
+        head :ok
+      else
+        head :unprocessable_content
+      end
+    rescue ActionController::ParameterMissing
+      head :unprocessable_content
+    end
+
+    private
+
+    def valid_signature?
+      signature_data = params.require(:signature)
+      timestamp = signature_data[:timestamp]
+      token = signature_data[:token]
+      signature = signature_data[:signature]
+
+      digest = OpenSSL::HMAC.hexdigest("SHA256", EdifyConfig.mailgun_webhook_signing_key, "#{timestamp}#{token}")
+      ActiveSupport::SecurityUtils.secure_compare(digest, signature)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   end
 
   namespace :webhooks do
+    resources :mailgun_events, only: [:create]
     resources :sendgrid_events, only: [:create]
   end
 

--- a/spec/controllers/webhooks/mailgun_events_controller_spec.rb
+++ b/spec/controllers/webhooks/mailgun_events_controller_spec.rb
@@ -1,0 +1,191 @@
+require "rails_helper"
+
+RSpec.describe Webhooks::MailgunEventsController do
+  describe "#create" do
+    subject(:make_request) { post :create, params: params, as: :json }
+
+    before { allow(controller).to receive(:valid_signature?).and_return(true) }
+
+    context "when the event is delivered" do
+      let(:params) do
+        {
+          signature: {
+            timestamp: "1683409840",
+            token: "random-token-string",
+            signature: "fake-signature",
+          },
+          event_data: {
+            event: "delivered",
+            id: "unique-event-id",
+            timestamp: 1_683_409_840.123,
+            recipient: "user@example.com",
+            message: {
+              headers: {
+                message_id: "abc123@edifyapp.org",
+              },
+            },
+            delivery_status: {
+              code: 250,
+              message: "OK",
+            },
+            ip: "1.2.3.4",
+            reason: nil,
+            client_info: {
+              user_agent: "Mozilla/5.0",
+            },
+          },
+        }
+      end
+
+      it "returns a 200 response" do
+        make_request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "creates a new Analytics::MailgunEvent record" do
+        expect { make_request }.to change(Analytics::MailgunEvent, :count).by(1)
+      end
+
+      it "saves the event attributes correctly" do
+        make_request
+        event = Analytics::MailgunEvent.last
+
+        expect(event).to have_attributes(
+          email: "user@example.com",
+          event: "delivered",
+          mailgun_event_id: "unique-event-id",
+          mailgun_message_id: "abc123@edifyapp.org",
+          ip: "1.2.3.4",
+          status: "250",
+          response: "OK",
+          useragent: "Mozilla/5.0",
+        )
+      end
+    end
+
+    context "when the event is failed" do
+      let(:params) do
+        {
+          signature: {
+            timestamp: "1683409840",
+            token: "random-token-string",
+            signature: "fake-signature",
+          },
+          event_data: {
+            event: "failed",
+            id: "failed-event-id",
+            timestamp: 1_683_409_840,
+            recipient: "bounced@example.com",
+            message: {
+              headers: {
+                message_id: "def456@edifyapp.org",
+              },
+            },
+            delivery_status: {
+              code: 550,
+              message: "Mailbox not found",
+            },
+            ip: nil,
+            reason: "bounce",
+            client_info: {},
+          },
+        }
+      end
+
+      it "returns a 200 response" do
+        make_request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "saves the reason and status" do
+        make_request
+        event = Analytics::MailgunEvent.last
+
+        expect(event).to have_attributes(
+          email: "bounced@example.com",
+          event: "failed",
+          reason: "bounce",
+          status: "550",
+          response: "Mailbox not found",
+        )
+      end
+    end
+
+    context "when the signature is invalid" do
+      before { allow(controller).to receive(:valid_signature?).and_return(false) }
+
+      let(:params) do
+        {
+          signature: {
+            timestamp: "1683409840",
+            token: "random-token-string",
+            signature: "bad-signature",
+          },
+          event_data: {
+            event: "delivered",
+            id: "unique-event-id",
+            timestamp: 1_683_409_840,
+            recipient: "user@example.com",
+            message: { headers: { message_id: "abc123@edifyapp.org" } },
+            delivery_status: { code: 250, message: "OK" },
+          },
+        }
+      end
+
+      it "returns a 401 response" do
+        make_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "does not create a record" do
+        expect { make_request }.not_to(change(Analytics::MailgunEvent, :count))
+      end
+    end
+
+    context "when event_data is missing" do
+      let(:params) do
+        {
+          signature: {
+            timestamp: "1683409840",
+            token: "random-token-string",
+            signature: "fake-signature",
+          },
+        }
+      end
+
+      it "returns a 422 response" do
+        make_request
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "when a required attribute is missing" do
+      let(:params) do
+        {
+          signature: {
+            timestamp: "1683409840",
+            token: "random-token-string",
+            signature: "fake-signature",
+          },
+          event_data: {
+            event: "delivered",
+            id: "unique-event-id",
+            timestamp: nil,
+            recipient: "user@example.com",
+            message: { headers: { message_id: "abc123@edifyapp.org" } },
+            delivery_status: { code: 250, message: "OK" },
+          },
+        }
+      end
+
+      it "returns a 422 response" do
+        make_request
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "does not create a record" do
+        expect { make_request }.not_to(change(Analytics::MailgunEvent, :count))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `Webhooks::MailgunEventsController` with HMAC-SHA256 signature verification
- Parses Mailgun webhook payloads and creates `Analytics::MailgunEvent` records
- Add route `POST /webhooks/mailgun_events`
- Add 10 controller specs covering delivered/failed events, invalid signatures, missing params, and missing required attributes

Closes #229. Part of #226.

## Cloudflare note
If the app is behind Cloudflare, Bot Fight Mode may block Mailgun webhook requests with a 403. Fix: disable Bot Fight Mode or create a WAF exception for `/webhooks/mailgun_events`.

## Test plan
- [x] Verify all tests pass (`bundle exec rspec` — 209 examples, 0 failures)
- [x] After deploy, configure webhook URL in Mailgun dashboard (Sending > Webhooks)
- [x] Test with curl: `curl -s -o /dev/null -w "%{http_code}" -X POST https://edifyapp.org/webhooks/mailgun_events -H "Content-Type: application/json" -d '{}'` — should return 422 (not 403)
- [ ] Verify webhook events appear in `/madmin/analytics/email_events` with type `Analytics::MailgunEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)