### PR TITLE
Fix Mailgun webhook to use hyphenated param keys

### DIFF
--- a/app/controllers/webhooks/mailgun_events_controller.rb
+++ b/app/controllers/webhooks/mailgun_events_controller.rb
@@ -5,19 +5,19 @@ module Webhooks
     def create
       return head :unauthorized unless valid_signature?
 
-      event_data = params.require(:event_data)
+      event_data = params.require("event-data")
 
       mailgun_event = Analytics::MailgunEvent.new(
         recipient: event_data[:recipient],
         timestamp: event_data[:timestamp],
         event: event_data[:event],
         mailgun_event_id: event_data[:id],
-        mailgun_message_id: event_data.dig(:message, :headers, :message_id),
+        mailgun_message_id: event_data.dig(:message, :headers, "message-id"),
         ip: event_data[:ip],
         reason: event_data[:reason],
-        status: event_data.dig(:delivery_status, :code)&.to_s,
-        response: event_data.dig(:delivery_status, :message),
-        useragent: event_data.dig(:client_info, :user_agent),
+        status: event_data.dig("delivery-status", :code)&.to_s,
+        response: event_data.dig("delivery-status", :message),
+        useragent: event_data.dig("client-info", "user-agent"),
       )
 
       if mailgun_event.save

--- a/spec/controllers/webhooks/mailgun_events_controller_spec.rb
+++ b/spec/controllers/webhooks/mailgun_events_controller_spec.rb
@@ -9,29 +9,29 @@ RSpec.describe Webhooks::MailgunEventsController do
     context "when the event is delivered" do
       let(:params) do
         {
-          signature: {
-            timestamp: "1683409840",
-            token: "random-token-string",
-            signature: "fake-signature",
+          "signature" => {
+            "timestamp" => "1683409840",
+            "token" => "random-token-string",
+            "signature" => "fake-signature",
           },
-          event_data: {
-            event: "delivered",
-            id: "unique-event-id",
-            timestamp: 1_683_409_840.123,
-            recipient: "user@example.com",
-            message: {
-              headers: {
-                message_id: "abc123@edifyapp.org",
+          "event-data" => {
+            "event" => "delivered",
+            "id" => "unique-event-id",
+            "timestamp" => 1_683_409_840.123,
+            "recipient" => "user@example.com",
+            "message" => {
+              "headers" => {
+                "message-id" => "abc123@edifyapp.org",
               },
             },
-            delivery_status: {
-              code: 250,
-              message: "OK",
+            "delivery-status" => {
+              "code" => 250,
+              "message" => "OK",
             },
-            ip: "1.2.3.4",
-            reason: nil,
-            client_info: {
-              user_agent: "Mozilla/5.0",
+            "ip" => "1.2.3.4",
+            "reason" => nil,
+            "client-info" => {
+              "user-agent" => "Mozilla/5.0",
             },
           },
         }
@@ -66,28 +66,28 @@ RSpec.describe Webhooks::MailgunEventsController do
     context "when the event is failed" do
       let(:params) do
         {
-          signature: {
-            timestamp: "1683409840",
-            token: "random-token-string",
-            signature: "fake-signature",
+          "signature" => {
+            "timestamp" => "1683409840",
+            "token" => "random-token-string",
+            "signature" => "fake-signature",
           },
-          event_data: {
-            event: "failed",
-            id: "failed-event-id",
-            timestamp: 1_683_409_840,
-            recipient: "bounced@example.com",
-            message: {
-              headers: {
-                message_id: "def456@edifyapp.org",
+          "event-data" => {
+            "event" => "failed",
+            "id" => "failed-event-id",
+            "timestamp" => 1_683_409_840,
+            "recipient" => "bounced@example.com",
+            "message" => {
+              "headers" => {
+                "message-id" => "def456@edifyapp.org",
               },
             },
-            delivery_status: {
-              code: 550,
-              message: "Mailbox not found",
+            "delivery-status" => {
+              "code" => 550,
+              "message" => "Mailbox not found",
             },
-            ip: nil,
-            reason: "bounce",
-            client_info: {},
+            "ip" => nil,
+            "reason" => "bounce",
+            "client-info" => {},
           },
         }
       end
@@ -116,18 +116,18 @@ RSpec.describe Webhooks::MailgunEventsController do
 
       let(:params) do
         {
-          signature: {
-            timestamp: "1683409840",
-            token: "random-token-string",
-            signature: "bad-signature",
+          "signature" => {
+            "timestamp" => "1683409840",
+            "token" => "random-token-string",
+            "signature" => "bad-signature",
           },
-          event_data: {
-            event: "delivered",
-            id: "unique-event-id",
-            timestamp: 1_683_409_840,
-            recipient: "user@example.com",
-            message: { headers: { message_id: "abc123@edifyapp.org" } },
-            delivery_status: { code: 250, message: "OK" },
+          "event-data" => {
+            "event" => "delivered",
+            "id" => "unique-event-id",
+            "timestamp" => 1_683_409_840,
+            "recipient" => "user@example.com",
+            "message" => { "headers" => { "message-id" => "abc123@edifyapp.org" } },
+            "delivery-status" => { "code" => 250, "message" => "OK" },
           },
         }
       end
@@ -142,13 +142,13 @@ RSpec.describe Webhooks::MailgunEventsController do
       end
     end
 
-    context "when event_data is missing" do
+    context "when event-data is missing" do
       let(:params) do
         {
-          signature: {
-            timestamp: "1683409840",
-            token: "random-token-string",
-            signature: "fake-signature",
+          "signature" => {
+            "timestamp" => "1683409840",
+            "token" => "random-token-string",
+            "signature" => "fake-signature",
           },
         }
       end
@@ -162,18 +162,18 @@ RSpec.describe Webhooks::MailgunEventsController do
     context "when a required attribute is missing" do
       let(:params) do
         {
-          signature: {
-            timestamp: "1683409840",
-            token: "random-token-string",
-            signature: "fake-signature",
+          "signature" => {
+            "timestamp" => "1683409840",
+            "token" => "random-token-string",
+            "signature" => "fake-signature",
           },
-          event_data: {
-            event: "delivered",
-            id: "unique-event-id",
-            timestamp: nil,
-            recipient: "user@example.com",
-            message: { headers: { message_id: "abc123@edifyapp.org" } },
-            delivery_status: { code: 250, message: "OK" },
+          "event-data" => {
+            "event" => "delivered",
+            "id" => "unique-event-id",
+            "timestamp" => nil,
+            "recipient" => "user@example.com",
+            "message" => { "headers" => { "message-id" => "abc123@edifyapp.org" } },
+            "delivery-status" => { "code" => 250, "message" => "OK" },
           },
         }
       end


### PR DESCRIPTION
## Summary
- Mailgun sends JSON with hyphenated keys (`event-data`, `delivery-status`, `client-info`, `message-id`, `user-agent`)
- Rails does **not** auto-convert these to underscored symbols in params
- Update controller to use literal string keys: `params.require("event-data")`, `event_data.dig("delivery-status", :code)`, etc.
- Update specs to send hyphenated keys matching the real Mailgun payload format

Discovered during production testing — Mailgun test webhooks were returning 422 because `params.require(:event_data)` raised `ParameterMissing` when the actual key was `"event-data"`.

## Test plan
- [ ] Verify all tests pass (`bundle exec rspec` — 209 examples, 0 failures)
- [ ] After deploy, re-test Mailgun webhooks from the Mailgun dashboard — should return 200
- [ ] Verify events appear in `/madmin/analytics/email_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)