### PR TITLE
Remove unused Sentry credential accessor

### DIFF
--- a/config/initializers/01_edify_config.rb
+++ b/config/initializers/01_edify_config.rb
@@ -42,8 +42,4 @@ class EdifyConfig
   def self.scout_apm_logs_ingest_key
     Rails.application.credentials.dig(:scout, :logs_ingest_key) || "test_key"
   end
-
-  def self.sentry_dsn
-    Rails.application.credentials.dig(:sentry, :dsn)
-  end
 end


### PR DESCRIPTION
## Summary
- Remove unused `sentry_dsn` method from `EdifyConfig`
- Sentry was replaced by Scout APM in #221; this accessor was left behind

Closes #221.

## Test plan
- [x] All tests pass (`bundle exec rspec` — 203 examples, 0 failures)
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)