### PR TITLE
Fix ArgumentError in notifications with multiple recipients

### DIFF
--- a/app/jobs/unit_access_approval_job.rb
+++ b/app/jobs/unit_access_approval_job.rb
@@ -2,6 +2,8 @@ class UnitAccessApprovalJob < ::ApplicationJob
   queue_as :default
 
   def perform(unit:, user:)
-    ::UnitAccessApprovalNotification.with(user: user).deliver_later(unit.users.approvers)
+    unit.users.approvers.find_each do |approver|
+      ::UnitAccessApprovalNotification.with(user: user).deliver_later(approver)
+    end
   end
 end

--- a/app/jobs/unit_access_rejection_job.rb
+++ b/app/jobs/unit_access_rejection_job.rb
@@ -2,6 +2,8 @@ class UnitAccessRejectionJob < ::ApplicationJob
   queue_as :default
 
   def perform(unit:, user:)
-    ::UnitAccessRejectionNotification.with(user: user).deliver_later(unit.users.approvers)
+    unit.users.approvers.find_each do |approver|
+      ::UnitAccessRejectionNotification.with(user: user).deliver_later(approver)
+    end
   end
 end

--- a/app/jobs/unit_access_request_job.rb
+++ b/app/jobs/unit_access_request_job.rb
@@ -2,6 +2,8 @@ class UnitAccessRequestJob < ::ApplicationJob
   queue_as :default
 
   def perform(unit:, user:)
-    ::UnitAccessRequestNotification.with(user: user).deliver_later(unit.users.approvers)
+    unit.users.approvers.find_each do |approver|
+      ::UnitAccessRequestNotification.with(user: user).deliver_later(approver)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,9 @@ class User < ApplicationRecord
   def send_welcome_notifications
     return true unless newly_confirmed?
 
-    ::NewUserAdminNotification.with(user: self).deliver_later(::User.admin.all)
+    ::User.admin.find_each do |admin|
+      ::NewUserAdminNotification.with(user: self).deliver_later(admin)
+    end
     ::NewUserNotification.with(user: self).deliver_later(self)
   end
 

--- a/app/utils/check_meetings_and_notify.rb
+++ b/app/utils/check_meetings_and_notify.rb
@@ -18,13 +18,17 @@ class CheckMeetingsAndNotify
   attr_reader :unit, :today
 
   def notify_missing_dates
-    ::MissingMeetingsNotification.with(dates: notifiable_missing_dates).deliver_later(unit.users.meeting_schedulers)
+    unit.users.meeting_schedulers.find_each do |user|
+      ::MissingMeetingsNotification.with(dates: notifiable_missing_dates).deliver_later(user)
+    end
   end
 
   def notify_incomplete_meetings
     notifiable_incomplete_meetings.each do |meeting|
-      users_to_notify = meeting.scheduler || unit.users.meeting_schedulers
-      ::IncompleteMeetingNotification.with(meeting: meeting).deliver_later(users_to_notify)
+      recipients = meeting.scheduler ? [meeting.scheduler] : unit.users.meeting_schedulers.to_a
+      recipients.each do |user|
+        ::IncompleteMeetingNotification.with(meeting: meeting).deliver_later(user)
+      end
     end
   end
 

--- a/spec/jobs/unit_access_approval_job_spec.rb
+++ b/spec/jobs/unit_access_approval_job_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe UnitAccessApprovalJob, type: :job do
 
     before { allow(::UnitAccessApprovalNotification).to receive(:deliver_later) }
 
-    it "delivers a message" do
+    it "delivers a message to each approver" do
       mock_notification = instance_double(UnitAccessApprovalNotification)
       allow(UnitAccessApprovalNotification).to receive(:with).with(user: user).and_return(mock_notification)
-      expect(mock_notification).to receive(:deliver_later).with(unit.users.approvers)
+      unit.users.approvers.each do |approver|
+        expect(mock_notification).to receive(:deliver_later).with(approver)
+      end
 
       perform_job
     end

--- a/spec/jobs/unit_access_rejection_job_spec.rb
+++ b/spec/jobs/unit_access_rejection_job_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe UnitAccessRejectionJob, type: :job do
 
     before { allow(::UnitAccessRejectionNotification).to receive(:deliver_later) }
 
-    it "delivers a message" do
+    it "delivers a message to each approver" do
       mock_notification = instance_double(UnitAccessRejectionNotification)
       allow(UnitAccessRejectionNotification).to receive(:with).with(user: user).and_return(mock_notification)
-      expect(mock_notification).to receive(:deliver_later).with(unit.users.approvers)
+      unit.users.approvers.each do |approver|
+        expect(mock_notification).to receive(:deliver_later).with(approver)
+      end
 
       perform_job
     end

--- a/spec/jobs/unit_access_request_job_spec.rb
+++ b/spec/jobs/unit_access_request_job_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe UnitAccessRequestJob, type: :job do
 
     before { allow(::UnitAccessRequestNotification).to receive(:deliver_later) }
 
-    it "delivers a message" do
+    it "delivers a message to each approver" do
       mock_notification = instance_double(UnitAccessRequestNotification)
       allow(UnitAccessRequestNotification).to receive(:with).with(user: user).and_return(mock_notification)
-      expect(mock_notification).to receive(:deliver_later).with(unit.users.approvers)
+      unit.users.approvers.each do |approver|
+        expect(mock_notification).to receive(:deliver_later).with(approver)
+      end
 
       perform_job
     end

--- a/spec/utils/check_meetings_and_notify_spec.rb
+++ b/spec/utils/check_meetings_and_notify_spec.rb
@@ -19,9 +19,11 @@ describe CheckMeetingsAndNotify do
     let(:test_date) { "2022-04-30" }
     let(:expected_missing_dates) { ["2022-05-08", "2022-05-22"].map(&:to_date) }
 
-    it "sends notifications of missing dates to unit users" do
+    it "sends notifications of missing dates to each meeting scheduler" do
       expect(::MissingMeetingsNotification).to receive(:with).with(dates: expected_missing_dates)
-      expect(missing_meetings_notification).to receive(:deliver_later).with(unit.users.bishopric)
+      unit.users.meeting_schedulers.each do |user|
+        expect(missing_meetings_notification).to receive(:deliver_later).with(user)
+      end
       subject.perform!
     end
   end
@@ -41,9 +43,11 @@ describe CheckMeetingsAndNotify do
     let(:incomplete_meeting) { unit.meetings.find_by(date: "2022-05-15") }
 
     context "when the meeting has no scheduler" do
-      it "sends an incomplete meeting notification to unit users" do
+      it "sends an incomplete meeting notification to each meeting scheduler" do
         expect(::IncompleteMeetingNotification).to receive(:with).with(meeting: incomplete_meeting)
-        expect(incomplete_meeting_notification).to receive(:deliver_later).with(unit.users.bishopric)
+        unit.users.meeting_schedulers.each do |user|
+          expect(incomplete_meeting_notification).to receive(:deliver_later).with(user)
+        end
         subject.perform!
       end
     end


### PR DESCRIPTION
## Summary
- Noticed 1.x `deliver_later` expects a single recipient, but we were passing ActiveRecord relations, causing `ArgumentError: wrong number of arguments (given 2, expected 1)`
- Changed all 5 call sites to iterate over recipients and deliver individually
- Updated specs to expect single-recipient delivery (first commit fails against old code, second commit fixes it)

Fixes #227

## Test plan
- [x] Updated specs reproduce the bug against old code (red)
- [x] All 203 specs pass after fix (green)
- [x] Rubocop clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)