### PR TITLE
Remove Heroku-specific deployment files

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,6 +1,0 @@
-libglib2.0-0
-libglib2.0-dev
-libpoppler-glib8
-libheif-dev
-libvips-dev
-libvips

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,0 @@
-web: bin/rails server
-worker: bundle exec rake solid_queue:start
-release: bundle exec rails db:migrate


### PR DESCRIPTION
## Summary
- Delete `Procfile` and `Aptfile`, both leftovers from the old Heroku deployment. The app is now on Digital Ocean via Hatchbox, so neither is consumed.
- `Procfile.dev` and `.foreman` are retained — they're used by Foreman for local dev, not Heroku.

Closes #243

## Test plan
- [x] CI passes (no deploy-related paths exercised by the test suite).
- [x] Local dev still starts via `foreman start -f Procfile.dev` (unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)