### PR TITLE
Build JS and CSS assets during bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -20,6 +20,9 @@ FileUtils.chdir APP_ROOT do
   # Install JavaScript dependencies
   system! 'bin/yarn'
 
+  puts "\n== Building assets =="
+  system! "yarn build && yarn build:css"
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"


### PR DESCRIPTION
## Summary
- Adds `yarn build && yarn build:css` step to `bin/setup` after yarn dependency installation
- Ensures `app/assets/builds/` is populated so system tests pass and the app renders correctly out of the box

## Test plan
- [ ] Run `bin/setup` on a fresh checkout and verify the app loads without asset errors
- [ ] Confirm system tests pass without a manual build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)