### PR TITLE
Update README to reflect Rails 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ruby on Rails
 This application requires:
 
 - Ruby 4.0
-- Rails 8.0
+- Rails 8.1
 
 Learn more about [Installing Rails](https://gorails.com/setup/osx/10.12-sierra).
 


### PR DESCRIPTION
## Summary

Follow-up to #247 — the Ruby on Rails section of the README still listed Rails 8.0.

## Test plan

- [x] Visual diff of README

🤖 Generated with [Claude Code](https://claude.com/claude-code)