### PR TITLE
Run rubocop only on files changed in the PR

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
@@ -38,9 +40,11 @@ jobs:
         run: |
           yarn install --pure-lockfile
 
-      - name: Run linter
+      - name: Run rubocop on changed files
         run: |
-          bin/rubocop --parallel
+          { git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...HEAD \
+            | grep -E '\.(rb|rake)$|(^|/)(Rakefile|Gemfile)$' || true; } \
+            | xargs --no-run-if-empty bundle exec rubocop --force-exclusion
 
       - name: Run security checks
         run: |


### PR DESCRIPTION
## Summary

Ports OST's linter approach: instead of running `bin/rubocop --parallel` over the whole tree, diff the PR branch against its base commit and run rubocop **only on the changed Ruby files**.

```yaml
- name: Run rubocop on changed files
  run: |
    { git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...HEAD \
      | grep -E '\.(rb|rake)$|(^|/)(Rakefile|Gemfile)$' || true; } \
      | xargs --no-run-if-empty bundle exec rubocop --force-exclusion
```

Why:
- A newly-enabled cop no longer forces a tree-wide cleanup in an unrelated PR — you only fix offenses in files you actually touch.
- `--force-exclusion` keeps `.rubocop.yml` `Exclude` patterns in effect even when files are passed explicitly.
- `--diff-filter=d` skips deleted files; `--no-run-if-empty` no-ops a PR with no Ruby changes.

Also adds `fetch-depth: 0` to the linters checkout so the base commit is available for the diff.

## Testing

CI-config-only change. The linter step will run against this PR's own diff.