### PR TITLE
Add "Hide moved members" filter to members index

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -121,6 +121,29 @@ module DropdownHelper
     build_dropdown_menu(title, dropdown_items, options)
   end
 
+  # Checkbox that hides "moved" members (those not in the unit's most recent
+  # import). "Not moved" is exactly synced_on >= unit.last_synced_on, so the
+  # checkbox rides the same Ransack `q` params as the filter dropdowns: checking
+  # it adds synced_on_gteq, unchecking clears it, while deep_merge preserves any
+  # other active filters/sort/search. Hidden until the unit has been imported.
+  def moved_filter_checkbox(request_params, unit)
+    return if unit.last_synced_on.blank?
+
+    currently_hidden = request_params.dig(:q, :synced_on_gteq).present?
+    toggle_url = url_for(request_params.deep_merge(q: { synced_on_gteq: currently_hidden ? nil : unit.last_synced_on }))
+
+    content_tag(:div, class: "form-check form-check-inline align-middle ms-md-2 mt-2 mt-md-0") do
+      concat check_box_tag("hide_moved", "1", currently_hidden,
+                           class: "form-check-input",
+                           data: {
+                             controller: "toggle-filter",
+                             toggle_filter_url_value: toggle_url,
+                             action: "change->toggle-filter#toggle",
+                           })
+      concat label_tag("hide_moved", "Hide moved members", class: "form-check-label")
+    end
+  end
+
   def filter_talks_matched_dropdown(request_params, options = {})
     existing_matched_filter = request_params.dig(:q, :member_id_null).presence
 

--- a/app/javascript/controllers/toggle_filter_controller.js
+++ b/app/javascript/controllers/toggle_filter_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Navigates to a pre-built filter URL when a control (e.g. a checkbox) toggles,
+// mirroring the behavior of clicking a filter dropdown link.
+export default class extends Controller {
+    static values = { url: String }
+
+    toggle() {
+        Turbo.visit(this.urlValue, { action: "advance" })
+    }
+}

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -21,7 +21,7 @@ class Member < ApplicationRecord
   after_save_commit :match_talks
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[birthdate gender last_talk_date name]
+    %w[birthdate gender last_talk_date name synced_on]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/app/views/members/_sort_and_filter_dropdowns.html.erb
+++ b/app/views/members/_sort_and_filter_dropdowns.html.erb
@@ -2,4 +2,5 @@
   <%= sort_members_dropdown(request.params, q, label: "Sort") %>
   <%= filter_members_age_dropdown(request.params, label: "Ages") %>
   <%= filter_members_gender_dropdown(request.params, label: "Genders") %>
+  <%= moved_filter_checkbox(request.params, current_unit) %>
 </div>

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -118,6 +118,34 @@ describe ::Member do
     end
   end
 
+  describe "filtering out moved members via a synced_on_gteq ransack query" do
+    subject(:filtered) do
+      unit.members.with_last_talk_date.ransack(synced_on_gteq: unit.last_synced_on).result.to_a
+    end
+
+    let(:unit) { units(:sunny_hills) }
+    let!(:current_member) do
+      unit.members.create!(name: "Current, One", gender: :male, birthdate: "1990-01-01", synced_on: "2022-04-15")
+    end
+    let!(:moved_member) do
+      unit.members.create!(name: "Moved, Two", gender: :male, birthdate: "1991-01-01", synced_on: "2022-04-10")
+    end
+    let!(:never_synced_member) do
+      unit.members.create!(name: "Never, Three", gender: :male, birthdate: "1992-01-01", synced_on: nil)
+    end
+
+    before { unit.update!(last_synced_on: "2022-04-15") }
+
+    it "exposes synced_on to ransack" do
+      expect(described_class.ransackable_attributes).to include("synced_on")
+    end
+
+    it "keeps only members synced in the most recent import" do
+      expect(filtered).to include(current_member)
+      expect(filtered).not_to include(moved_member, never_synced_member)
+    end
+  end
+
   describe "#paused?" do
     let(:result) { member.paused? }
     before { travel_to("2022-04-15") }

--- a/spec/system/members_index_spec.rb
+++ b/spec/system/members_index_spec.rb
@@ -67,6 +67,31 @@ describe "Visit the members index" do
     end
   end
 
+  context "when hiding moved members", :js do
+    before do
+      unit.update!(last_synced_on: Date.new(2022, 4, 15))
+      login_as bishopric_user, scope: :user
+    end
+
+    let!(:current_member) do
+      unit.members.create!(name: "Current Person", gender: :male, birthdate: "1990-01-01", synced_on: Date.new(2022, 4, 15))
+    end
+    let!(:moved_member) do
+      unit.members.create!(name: "Moved Person", gender: :male, birthdate: "1991-01-01", synced_on: Date.new(2022, 3, 1))
+    end
+
+    it "removes members not in the most recent import when the checkbox is checked" do
+      visit members_path
+      expect(page).to have_selector("#member_#{current_member.id}")
+      expect(page).to have_selector("#member_#{moved_member.id}")
+
+      check "Hide moved members"
+
+      expect(page).to have_selector("#member_#{current_member.id}")
+      expect(page).to have_no_selector("#member_#{moved_member.id}")
+    end
+  end
+
   def verify_members_present
     expect(page).to have_text "Members"
 


### PR DESCRIPTION
Closes #257.

## What

Adds a **"Hide moved members"** checkbox to the top filter row of the members index. When checked, members flagged **"Moved"** (those not in the unit's most recent import) are hidden, so leaders can focus on the current roster. Off by default.

![filter row: Sort ▾  Ages ▾  Genders ▾  ☑ Hide moved members]

## How

"Moved" is `synced_on.nil? || synced_on < unit.last_synced_on`, so **"not moved" is exactly `synced_on >= unit.last_synced_on`** (which also excludes never-synced members). That maps directly onto the Ransack `q` params every other filter already uses, so there's no new query machinery:

- **`Member.ransackable_attributes`** now includes `synced_on` (mirrors how `last_talk_date` is exposed). The filter is `q[synced_on_gteq] = current_unit.last_synced_on`; `MembersController#index` needs no change.
- **`moved_filter_checkbox` helper** renders the checkbox; its toggle URL `deep_merge`s into the current params (preserving any active sort/age/gender/search), and clears the predicate when unchecked — same mechanic as the existing filter dropdowns. Hidden until the unit has been imported (`last_synced_on` present).
- **`toggle_filter` Stimulus controller** Turbo-visits the toggle URL on `change`, matching how dropdown links navigate. Auto-registered via the existing `*_controller.js` glob.

## Tests

- **Model spec** (`spec/models/member_spec.rb`): `synced_on_gteq = last_synced_on` keeps only members synced in the latest import (excludes both earlier-synced and never-synced), and `synced_on` is ransackable.
- **System spec** (`spec/system/members_index_spec.rb`, `:js`): checking the box removes the moved member's card while the current one remains.

All green locally: model spec + full non-system suite (159 examples), the members system spec (7 examples incl. the new `:js` one), and RuboCop clean. Also verified by hand against a running dev instance (unfiltered 14 cards → hide-moved shows only current members, 0 "Moved" badges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)