### PR TITLE
Add bin/update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Setup the app by running the setup script:
 2. `$ ./bin/dev` to start the servers in your dev environment
 3. Type `localhost:3000` in a browser
 
+**Staying Up to Date**
+
+After pulling the latest master, run the update script to bring your development environment current:
+
+```bash
+$ ./bin/update
+```
+
+This installs any new Ruby and JavaScript dependencies, rebuilds assets, runs pending migrations, clears old logs and tempfiles, and restarts the application server.
+
 **Loading Test Fixtures**
 
 To populate your development database with test data from fixtures (users, units, meetings, etc.):

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ $ ./bin/update
 
 This installs any new Ruby and JavaScript dependencies, rebuilds assets, runs pending migrations, clears old logs and tempfiles, and restarts the application server.
 
+Optionally, you can also refresh your development database so it reflects any fixture changes that came in with the pull:
+
+```bash
+$ bundle exec rails db:from_fixtures
+```
+
+Note that this replaces existing data in your development database, so skip it if you have local data you want to keep.
+
 **Loading Test Fixtures**
 
 To populate your development database with test data from fixtures (users, units, meetings, etc.):

--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+require "fileutils"
+
+APP_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args, exception: true)
+end
+
+FileUtils.chdir APP_ROOT do
+  # This script is a way to update your development environment automatically.
+  # Run it after pulling changes to install dependencies, run new migrations,
+  # and restart the application server.
+  # Add necessary update steps to this file.
+
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
+
+  # Install JavaScript dependencies
+  system! "bin/yarn"
+
+  puts "\n== Building assets =="
+  system! "yarn build && yarn build:css"
+
+  puts "\n== Updating database =="
+  system! "bin/rails db:migrate"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Restarting application server =="
+  system! "bin/rails restart"
+end


### PR DESCRIPTION
## Summary

Adds the standard Rails `bin/update` convenience script, which this repo was missing. Run it after pulling changes to bring your development environment current.

Modeled on the `bin/update` in the OpenSplitTime repo, adapted to this app's `bin/setup` conventions (double-quoted strings, `system!` with `exception: true`, asset build step):

1. Installs Ruby dependencies (`bundle check || bundle install`)
2. Installs JavaScript dependencies (`bin/yarn`)
3. Builds JS and CSS assets
4. Runs pending migrations (`db:migrate` — no data_migrate gem here, so no `:with_data`)
5. Clears old logs and tempfiles
6. Restarts the application server

## Testing

Ran `bin/update` locally — all steps complete successfully (migrate was a no-op with no pending migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TieCXtqkhVPePJc2ffKe2b