### PR TITLE
Bump Node.js from 16 to 24

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
 
       - name: JS package cache
         id: cache-npm
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
 
       - name: JS package cache
         id: cache-npm

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 ruby 4.0.6
-nodejs 16.19.0
+nodejs 24.14.0


### PR DESCRIPTION
## Summary

Node 16 reached end-of-life in September 2023. This bumps the project to Node 24 (current LTS), matching OpenSplitTime.

- `.tool-versions`: `nodejs 16.19.0` → `nodejs 24.14.0` — this is what contributors now install via asdf per the updated README (#263), and what Hatchbox uses for production builds
- `.github/workflows/verify.yml`: `node-version: 16` → `24` in both jobs so CI matches

## Testing

With Node 24.14.0: `yarn install`, `yarn build` (esbuild), and `yarn build:css` (sass) all succeed with no warnings or errors.

## Notes

Complements #263 (README asdf instructions). First deploy after merge will build assets with Node 24 on Hatchbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TieCXtqkhVPePJc2ffKe2b